### PR TITLE
feat: create agenda item table, and automatically keep it up to date

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,17 @@
         ]
       }
     ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "args": "all",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "caughtErrorsIgnorePattern": "^_",
+        "destructuredArrayIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ],
     "sql/format": [
       2,
       {

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,3 +43,41 @@ jobs:
           CRON_SECRET: ${{ secrets.CRON_SECRET }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: npm run deploy:worker
+
+  update-database:
+    runs-on: ubuntu-latest
+    name: Update database
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      # i'm not sure why `npm run db:start` doesn't work here,
+      # but the remaining commands can't connect to the DB without using this action
+      - name: Start database
+        uses: hoverkraft-tech/compose-action@v2.2.0
+
+      - name: Run migrations
+        run: npm run db:run-migrations
+
+      - name: Run update script
+        run: npx tsx src/scripts/updateDatabase.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,8 +76,5 @@ jobs:
       - name: Start database
         uses: hoverkraft-tech/compose-action@v2.2.0
 
-      - name: Run migrations
-        run: npm run db:run-migrations
-
       - name: Run update script
         run: npx tsx src/scripts/updateDatabase.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,10 +71,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # i'm not sure why `npm run db:start` doesn't work here,
-      # but the remaining commands can't connect to the DB without using this action
-      - name: Start database
-        uses: hoverkraft-tech/compose-action@v2.2.0
-
       - name: Run update script
         run: npx tsx src/scripts/updateDatabase.ts

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run update script
-        run: npm run db:list-migrations
+      - name: Run migrations
+        run: npm run db:run-migrations

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -1,0 +1,36 @@
+name: Migrate database
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  migrate-database:
+    runs-on: ubuntu-latest
+    name: Migrate database
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Restore cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            .next/cache
+          # Generate a new cache whenever packages or source files change.
+          key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
+          # If source files changed but packages didn't, rebuild from a prior cache.
+          restore-keys: |
+            ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run update script
+        run: npm run db:list-migrations

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -2,7 +2,6 @@ name: Migrate database
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   migrate-database:

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:
+  pull_request:
 
 jobs:
   update-database:

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -6,7 +6,6 @@ on:
   schedule:
     - cron: '17 * * * *'
   workflow_dispatch:
-  pull_request:
 
 jobs:
   update-database:
@@ -37,4 +36,4 @@ jobs:
         run: npm ci
 
       - name: Run update script
-        run: npx tsx src/scripts/populateDatabase.ts
+        run: npx tsx src/scripts/updateDatabase.ts

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -1,21 +1,18 @@
-name: Deploy web app
+name: Update database
 
 on:
   push:
     branches: ['main']
   schedule:
     - cron: '17 * * * *'
-
   workflow_dispatch:
 
-concurrency:
-  group: 'frontend'
-  cancel-in-progress: false
-
 jobs:
-  deploy:
+  update-database:
     runs-on: ubuntu-latest
-    name: Deploy frontend
+    name: Update database
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -34,12 +31,9 @@ jobs:
           # If source files changed but packages didn't, rebuild from a prior cache.
           restore-keys: |
             ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-
+
       - name: Install dependencies
         run: npm ci
-      - name: Deploy to cloudflare pages
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CRON_SECRET: ${{ secrets.CRON_SECRET }}
-          DATABASE_URL: ${{ secrets.DATABASE_URL }}
-        run: npm run deploy:worker
+
+      - name: Run update script
+        run: npx tsx src/scripts/populateDatabase.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "prettier": "3.4.2",
         "react-email": "^3.0.3",
         "tailwindcss": "^3.4.1",
+        "tsx": "^4.19.3",
         "typescript": "^5",
         "typescript-eslint": "^8.18.0",
         "wrangler": "^3.91.0"
@@ -8569,7 +8570,7 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -8581,7 +8582,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -8706,13 +8707,14 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
-      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.0.tgz",
+      "integrity": "sha512-O7vun9Sf8DFjH2UtqK8Ku3LkquL9SZL8OLY1T5NZkA34+wG3OQF7cl4Ql8vdNzM6fzBbYfLaiRLIOZ+2FOCgBQ==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -8977,6 +8979,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.19.2.tgz",
@@ -8994,13 +9013,14 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -9074,13 +9094,14 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
-      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.0.tgz",
+      "integrity": "sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -12425,6 +12446,38 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/@tsconfig/node18": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-1.0.3.tgz",
@@ -12475,7 +12528,7 @@
       "version": "20.17.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.17.tgz",
       "integrity": "sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -12753,7 +12806,7 @@
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
       "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12774,7 +12827,7 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "acorn": "^8.11.0"
       },
@@ -13721,6 +13774,14 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -14426,11 +14487,12 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
-      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.0.tgz",
+      "integrity": "sha512-BXq5mqc8ltbaN34cDqWuYKyNhX8D/Z0J1xdtdQ8UcIIIyJyz+ZMKUt58tF3SrZ85jcfN/PZYhjR5uDQAYNVbuw==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -14438,40 +14500,42 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.1",
-        "@esbuild/android-arm": "0.23.1",
-        "@esbuild/android-arm64": "0.23.1",
-        "@esbuild/android-x64": "0.23.1",
-        "@esbuild/darwin-arm64": "0.23.1",
-        "@esbuild/darwin-x64": "0.23.1",
-        "@esbuild/freebsd-arm64": "0.23.1",
-        "@esbuild/freebsd-x64": "0.23.1",
-        "@esbuild/linux-arm": "0.23.1",
-        "@esbuild/linux-arm64": "0.23.1",
-        "@esbuild/linux-ia32": "0.23.1",
-        "@esbuild/linux-loong64": "0.23.1",
-        "@esbuild/linux-mips64el": "0.23.1",
-        "@esbuild/linux-ppc64": "0.23.1",
-        "@esbuild/linux-riscv64": "0.23.1",
-        "@esbuild/linux-s390x": "0.23.1",
-        "@esbuild/linux-x64": "0.23.1",
-        "@esbuild/netbsd-x64": "0.23.1",
-        "@esbuild/openbsd-arm64": "0.23.1",
-        "@esbuild/openbsd-x64": "0.23.1",
-        "@esbuild/sunos-x64": "0.23.1",
-        "@esbuild/win32-arm64": "0.23.1",
-        "@esbuild/win32-ia32": "0.23.1",
-        "@esbuild/win32-x64": "0.23.1"
+        "@esbuild/aix-ppc64": "0.25.0",
+        "@esbuild/android-arm": "0.25.0",
+        "@esbuild/android-arm64": "0.25.0",
+        "@esbuild/android-x64": "0.25.0",
+        "@esbuild/darwin-arm64": "0.25.0",
+        "@esbuild/darwin-x64": "0.25.0",
+        "@esbuild/freebsd-arm64": "0.25.0",
+        "@esbuild/freebsd-x64": "0.25.0",
+        "@esbuild/linux-arm": "0.25.0",
+        "@esbuild/linux-arm64": "0.25.0",
+        "@esbuild/linux-ia32": "0.25.0",
+        "@esbuild/linux-loong64": "0.25.0",
+        "@esbuild/linux-mips64el": "0.25.0",
+        "@esbuild/linux-ppc64": "0.25.0",
+        "@esbuild/linux-riscv64": "0.25.0",
+        "@esbuild/linux-s390x": "0.25.0",
+        "@esbuild/linux-x64": "0.25.0",
+        "@esbuild/netbsd-arm64": "0.25.0",
+        "@esbuild/netbsd-x64": "0.25.0",
+        "@esbuild/openbsd-arm64": "0.25.0",
+        "@esbuild/openbsd-x64": "0.25.0",
+        "@esbuild/sunos-x64": "0.25.0",
+        "@esbuild/win32-arm64": "0.25.0",
+        "@esbuild/win32-ia32": "0.25.0",
+        "@esbuild/win32-x64": "0.25.0"
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/android-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
-      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.0.tgz",
+      "integrity": "sha512-PTyWCYYiU0+1eJKmw21lWtC+d08JDZPQ5g+kFyxP0V+es6VPPSUhM6zk8iImp2jbV6GwjX4pap0JFbUQN65X1g==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -14481,13 +14545,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
-      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.0.tgz",
+      "integrity": "sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -14497,13 +14562,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/android-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
-      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.0.tgz",
+      "integrity": "sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -14513,13 +14579,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
-      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.0.tgz",
+      "integrity": "sha512-mVwdUb5SRkPayVadIOI78K7aAnPamoeFR2bT5nszFUZ9P8UpK4ratOdYbZZXYSqPKMHfS1wdHCJk1P1EZpRdvw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -14529,13 +14596,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
-      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.0.tgz",
+      "integrity": "sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -14545,13 +14613,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
-      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.0.tgz",
+      "integrity": "sha512-VN4ocxy6dxefN1MepBx/iD1dH5K8qNtNe227I0mnTRjry8tj5MRk4zprLEdG8WPyAPb93/e4pSgi1SoHdgOa4w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -14561,13 +14630,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
-      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.0.tgz",
+      "integrity": "sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -14577,13 +14647,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
-      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.0.tgz",
+      "integrity": "sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14593,13 +14664,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
-      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.0.tgz",
+      "integrity": "sha512-9QAQjTWNDM/Vk2bgBl17yWuZxZNQIF0OUUuPZRKoDtqF2k4EtYbpyiG5/Dk7nqeK6kIJWPYldkOcBqjXjrUlmg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14609,13 +14681,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
-      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.0.tgz",
+      "integrity": "sha512-43ET5bHbphBegyeqLb7I1eYn2P/JYGNmzzdidq/w0T8E2SsYL1U6un2NFROFRg1JZLTzdCoRomg8Rvf9M6W6Gg==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14625,13 +14698,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
-      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.0.tgz",
+      "integrity": "sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==",
       "cpu": [
         "loong64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14641,13 +14715,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
-      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.0.tgz",
+      "integrity": "sha512-nkAMFju7KDW73T1DdH7glcyIptm95a7Le8irTQNO/qtkoyypZAnjchQgooFUDQhNAy4iu08N79W4T4pMBwhPwQ==",
       "cpu": [
         "mips64el"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14657,13 +14732,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
-      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.0.tgz",
+      "integrity": "sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14673,13 +14749,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
-      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.0.tgz",
+      "integrity": "sha512-5S/rbP5OY+GHLC5qXp1y/Mx//e92L1YDqkiBbO9TQOvuFXM+iDqUNG5XopAnXoRH3FjIUDkeGcY1cgNvnXp/kA==",
       "cpu": [
         "riscv64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14689,13 +14766,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
-      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.0.tgz",
+      "integrity": "sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14705,13 +14783,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
-      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.0.tgz",
+      "integrity": "sha512-9yl91rHw/cpwMCNytUDxwj2XjFpxML0y9HAOH9pNVQDpQrBxHy01Dx+vaMu0N1CKa/RzBD2hB4u//nfc+Sd3Cw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -14721,13 +14800,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-jl+qisSB5jk01N5f7sPCsBENCOlPiS/xptD5yxOx2oqQfyourJwIKLRA2yqWdifj3owQZCL2sn6o08dBzZGQzA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -14737,13 +14817,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
-      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.0.tgz",
+      "integrity": "sha512-2gwwriSMPcCFRlPlKx3zLQhfN/2WjJ2NSlg5TKLQOJdV0mSxIcYNTMhk3H3ulL/cak+Xj0lY1Ym9ysDV1igceg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -14753,13 +14834,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
-      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.0.tgz",
+      "integrity": "sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -14769,13 +14851,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
-      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.0.tgz",
+      "integrity": "sha512-ZUAc2YK6JW89xTbXvftxdnYy3m4iHIkDtK3CLce8wg8M2L+YZhIvO1DKpxrd0Yr59AeNNkTiic9YLf6FTtXWMw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -14785,13 +14868,14 @@
       }
     },
     "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.1",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
-      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.0.tgz",
+      "integrity": "sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==",
       "cpu": [
         "ia32"
       ],
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -17481,6 +17565,14 @@
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true
     },
     "node_modules/mark.js": {
       "version": "8.11.1",
@@ -21429,6 +21521,70 @@
         "code-block-writer": "^13.0.1"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -21447,12 +21603,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tsx": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.2.tgz",
-      "integrity": "sha512-pOUl6Vo2LUq/bSa8S5q7b91cgNSjctn9ugq/+Mvow99qW6x/UZYwzxy/3NmqoT66eHYfCVvFvACC58UBPFf28g==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.19.3.tgz",
+      "integrity": "sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "esbuild": "~0.23.0",
+        "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
       },
       "bin": {
@@ -21611,7 +21768,7 @@
       "version": "5.7.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
       "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
-      "dev": true,
+      "devOptional": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21682,7 +21839,7 @@
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/unenv": {
       "version": "2.0.0-rc.1",
@@ -21826,6 +21983,14 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/vary": {
       "version": "1.1.2",
@@ -22534,6 +22699,17 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint",
+    "lint": "next lint && tsc --noEmit",
     "build:worker": "opennextjs-cloudflare",
     "dev:worker": "wrangler dev --port 8771",
     "preview-local:worker": "npm run build:worker && npm run dev:worker",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "civic-dashboard-web",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "next dev --turbo",
     "build": "next build",
@@ -67,6 +68,7 @@
     "prettier": "3.4.2",
     "react-email": "^3.0.3",
     "tailwindcss": "^3.4.1",
+    "tsx": "^4.19.3",
     "typescript": "^5",
     "typescript-eslint": "^8.18.0",
     "wrangler": "^3.91.0"

--- a/src/api/agendaItem.ts
+++ b/src/api/agendaItem.ts
@@ -61,23 +61,70 @@ export interface AgendaItem {
   neighbourhoodId?: number[];
 }
 
-export const fetchItems = async () => {
-  const now = new Date();
-  const nextMonth = new Date();
-  nextMonth.setMonth(nextMonth.getMonth() + 1);
+type AgendaItemFetchOptions = {
+  start: Date;
+  end: Date;
+};
+
+const fetchItemPage = async (
+  page: number,
+  { start, end }: AgendaItemFetchOptions,
+) => {
   const body = JSON.stringify({
     includeTitle: true,
     includeSummary: true,
     includeRecommendations: true,
     includeDecisions: true,
-    meetingFromDate: now.toISOString(),
-    meetingToDate: nextMonth.toISOString(),
+    meetingFromDate: start.toISOString(),
+    meetingToDate: end.toISOString(),
   });
 
   const response = await cityCouncilXSRFPost({
-    url: 'https://secure.toronto.ca/council/api/multiple/agenda-items.json?pageNumber=0&pageSize=200&sortOrder=meetingDate%20asc,referenceSort',
+    url: `https://secure.toronto.ca/council/api/multiple/agenda-items.json?pageNumber=${page}&pageSize=200&sortOrder=meetingDate%20asc,referenceSort`,
     body,
   });
 
-  return ((await response.json()) as ApiResponse).Records;
+  return (await response.json()) as ApiResponse;
+};
+
+const deduplicateAgendaItems = (items: AgendaItem[]) => {
+  const seen = new Map<string, AgendaItem>();
+
+  items.forEach((item) => {
+    const key = `${item.reference}-${item.meetingId}`;
+    const prev = seen.get(key);
+    if (prev === undefined || item.agendaItemId >= prev.agendaItemId) {
+      seen.set(key, item);
+      if (prev !== undefined) {
+        console.log(
+          `ignoring ${prev.agendaItemId} in favor of ${item.agendaItemId}`,
+        );
+      }
+    } else {
+      console.log(
+        `ignoring ${item.agendaItemId} in favor of ${prev.agendaItemId}`,
+      );
+    }
+  });
+
+  return [...seen.values()];
+};
+
+export const fetchAgendaItems = async (opts: AgendaItemFetchOptions) => {
+  let pageNumber = 0;
+  let totalPages = 1;
+  const records: AgendaItem[] = [];
+
+  while (pageNumber < totalPages) {
+    const page = await fetchItemPage(pageNumber, opts);
+    records.push(...page.Records);
+    totalPages = page.TotalPages;
+    pageNumber++;
+    if (pageNumber < totalPages) {
+      // wait a second before fetching again to avoid overloading the TMMIS API
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+
+  return deduplicateAgendaItems(records);
 };

--- a/src/app/actions/page.tsx
+++ b/src/app/actions/page.tsx
@@ -1,9 +1,12 @@
 import { fetchDecisionBodies } from '@/api/decisionBody';
-import { fetchItems } from '@/api/agendaItem';
+import { fetchAgendaItems } from '@/api/agendaItem';
 import { AgendaItemList } from '@/components/AgendaItemList';
 
 export default async function Home() {
-  const items = await fetchItems();
+  const now = new Date();
+  const nextMonth = new Date();
+  nextMonth.setMonth(nextMonth.getMonth() + 1);
+  const items = await fetchAgendaItems({ start: now, end: nextMonth });
   const decisionBodies = await fetchDecisionBodies();
 
   return (

--- a/src/database/allDbTypes.d.ts
+++ b/src/database/allDbTypes.d.ts
@@ -1,6 +1,10 @@
 // This is the one place allowed to import from generated types as here is were we re-export them
 // eslint-disable-next-line no-restricted-imports
 import * as generated from '@/database/generatedDbTypes';
+
+// eslint-disable-next-line no-restricted-imports
+export * from '@/database/generatedDbTypes';
+
 // Currently keysely codegen does not support materialized views.
 // For now we define their type manually here
 

--- a/src/database/columns.ts
+++ b/src/database/columns.ts
@@ -1,17 +1,6 @@
-import { AgendaItem } from '@/database/allDbTypes';
+import { RawAgendaItemConsiderations } from '@/database/allDbTypes';
 
-type Assert<_T extends true> = never;
-type Equivalent<A extends string, B extends string> = A extends B
-  ? B extends A
-    ? true
-    : `${A} does not match ${B}`
-  : `${B} does not match ${A}`;
-type ColumnsMatch<A extends object, B extends readonly string[]> = Equivalent<
-  keyof A & string,
-  B[number]
->;
-
-export const agendaItemColumns = [
+export const agendaItemConflictColumns = [
   'address',
   'agendaCd',
   'agendaItemAddress',
@@ -39,8 +28,4 @@ export const agendaItemColumns = [
   'termId',
   'termYear',
   'wardId',
-] as const;
-
-type _AssertAgendaItemColumnsComplete = Assert<
-  ColumnsMatch<AgendaItem, typeof agendaItemColumns>
->;
+] as const satisfies (keyof RawAgendaItemConsiderations)[];

--- a/src/database/columns.ts
+++ b/src/database/columns.ts
@@ -1,0 +1,46 @@
+import { AgendaItem } from '@/database/allDbTypes';
+
+type Assert<_T extends true> = never;
+type Equivalent<A extends string, B extends string> = A extends B
+  ? B extends A
+    ? true
+    : `${A} does not match ${B}`
+  : `${B} does not match ${A}`;
+type ColumnsMatch<A extends object, B extends readonly string[]> = Equivalent<
+  keyof A & string,
+  B[number]
+>;
+
+export const agendaItemColumns = [
+  'address',
+  'agendaCd',
+  'agendaItemAddress',
+  'agendaItemId',
+  'agendaItemRecommendation',
+  'agendaItemSummary',
+  'agendaItemTitle',
+  'backgroundAttachmentId',
+  'councilAgendaItemId',
+  'decisionAdvice',
+  'decisionBodyId',
+  'decisionBodyName',
+  'decisionRecommendations',
+  'geoLocation',
+  'id',
+  'itemProcessId',
+  'itemStatus',
+  'meetingDate',
+  'meetingId',
+  'meetingNumber',
+  'neighbourhoodId',
+  'planningApplicationNumber',
+  'reference',
+  'subjectTerms',
+  'termId',
+  'termYear',
+  'wardId',
+] as const;
+
+type _AssertAgendaItemColumnsComplete = Assert<
+  ColumnsMatch<AgendaItem, typeof agendaItemColumns>
+>;

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -30,9 +30,9 @@ export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
 export interface AgendaItem {
   /**
-   * Array of addresses as strings
+   * Array of addresses as strings.
    */
-  address: Json | null;
+  address: string[] | null;
   /**
    * Agenda committe descriptor, first half of second component of reference
    */
@@ -60,7 +60,7 @@ export interface AgendaItem {
   /**
    * Array of TMMIS IDs
    */
-  backgroundAttachmentId: Json | null;
+  backgroundAttachmentId: number[] | null;
   /**
    * TMMIS ID
    */
@@ -82,9 +82,9 @@ export interface AgendaItem {
    */
   decisionRecommendations: string | null;
   /**
-   * Array of lat/lon coordinates
+   * Array of lat/lon coordinates stored as strings.
    */
-  geoLocation: Json | null;
+  geoLocation: string[] | null;
   /**
    * auto-generated pkey, prefer using reference and meetingId to distinguish agenda items
    */
@@ -109,9 +109,12 @@ export interface AgendaItem {
    * Which meeting in the current year, second half of second component of reference
    */
   meetingNumber: string;
-  neighbourhoodId: Json | null;
   /**
    * Array of TMMIS IDs
+   */
+  neighbourhoodId: number[] | null;
+  /**
+   * Comma separated list of text reference numbers.
    */
   planningApplicationNumber: string | null;
   /**
@@ -119,7 +122,7 @@ export interface AgendaItem {
    */
   reference: string;
   /**
-   * Array of TMMIS IDs
+   * Semi-colon/comma separated string
    */
   subjectTerms: string;
   /**
@@ -130,7 +133,10 @@ export interface AgendaItem {
    * Year of term, first component of reference
    */
   termYear: string;
-  wardId: Json | null;
+  /**
+   * Array of TMMIS IDs
+   */
+  wardId: number[] | null;
 }
 
 export interface RawContacts {

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -139,6 +139,10 @@ export interface RawAgendaItemConsiderations {
   wardId: number[] | null;
 }
 
+export interface RawAgendaItems {
+  data: Json;
+}
+
 export interface RawContacts {
   addressLine1: string | null;
   addressLine2: string | null;
@@ -182,6 +186,7 @@ export interface RawVotes {
 
 export interface DB {
   RawAgendaItemConsiderations: RawAgendaItemConsiderations;
+  RawAgendaItems: RawAgendaItems;
   RawContacts: RawContacts;
   RawVotes: RawVotes;
 }

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -29,31 +29,106 @@ export type JsonPrimitive = boolean | number | string | null;
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
 export interface AgendaItem {
+  /**
+   * Array of addresses as strings
+   */
   address: Json | null;
+  /**
+   * Agenda committe descriptor, first half of second component of reference
+   */
   agendaCd: string;
+  /**
+   * Array of address objects, see api/agendaItem.ts
+   */
   agendaItemAddress: Json | null;
+  /**
+   * TMMIS ID
+   */
   agendaItemId: number;
+  /**
+   * HTML content
+   */
   agendaItemRecommendation: string | null;
+  /**
+   * HTML content
+   */
   agendaItemSummary: string;
+  /**
+   * Plain text content
+   */
   agendaItemTitle: string;
+  /**
+   * Array of TMMIS IDs
+   */
   backgroundAttachmentId: Json | null;
+  /**
+   * TMMIS ID
+   */
   councilAgendaItemId: number;
+  /**
+   * HTML content
+   */
   decisionAdvice: string | null;
+  /**
+   * TMMIS ID
+   */
   decisionBodyId: number;
+  /**
+   * May be better to denormalize into a decision body table
+   */
   decisionBodyName: string;
+  /**
+   * HTML content
+   */
   decisionRecommendations: string | null;
+  /**
+   * Array of lat/lon coordinates
+   */
   geoLocation: Json | null;
+  /**
+   * auto-generated pkey, prefer using reference and meetingId to distinguish agenda items
+   */
   id: Generated<string>;
+  /**
+   * Unknown purpose
+   */
   itemProcessId: number;
+  /**
+   * An enumeration that we havent yet documented the full extend of
+   */
   itemStatus: string;
+  /**
+   * Unix timestamp in millseconds
+   */
   meetingDate: Int8;
+  /**
+   * TMMIS ID
+   */
   meetingId: number;
+  /**
+   * Which meeting in the current year, second half of second component of reference
+   */
   meetingNumber: string;
   neighbourhoodId: Json | null;
+  /**
+   * Array of TMMIS IDs
+   */
   planningApplicationNumber: string | null;
+  /**
+   * Reference number, e.g. 2024.EX19.2
+   */
   reference: string;
+  /**
+   * Array of TMMIS IDs
+   */
   subjectTerms: string;
+  /**
+   * TMMIS ID
+   */
   termId: number;
+  /**
+   * Year of term, first component of reference
+   */
   termYear: string;
   wardId: Json | null;
 }

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -5,11 +5,58 @@
 
 import type { ColumnType } from 'kysely';
 
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
+
 export type Int8 = ColumnType<
   string,
   bigint | number | string,
   bigint | number | string
 >;
+
+export type Json = JsonValue;
+
+export type JsonArray = JsonValue[];
+
+export type JsonObject = {
+  [x: string]: JsonValue | undefined;
+};
+
+export type JsonPrimitive = boolean | number | string | null;
+
+export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
+
+export interface AgendaItem {
+  address: Json | null;
+  agendaCd: string;
+  agendaItemAddress: Json | null;
+  agendaItemId: number;
+  agendaItemRecommendation: string | null;
+  agendaItemSummary: string;
+  agendaItemTitle: string;
+  backgroundAttachmentId: Json | null;
+  councilAgendaItemId: number;
+  decisionAdvice: string | null;
+  decisionBodyId: number;
+  decisionBodyName: string;
+  decisionRecommendations: string | null;
+  geoLocation: Json | null;
+  id: Generated<string>;
+  itemProcessId: number;
+  itemStatus: string;
+  meetingDate: Int8;
+  meetingId: number;
+  meetingNumber: string;
+  neighbourhoodId: Json | null;
+  planningApplicationNumber: string | null;
+  reference: string;
+  subjectTerms: string;
+  termId: number;
+  termYear: string;
+  wardId: Json | null;
+}
 
 export interface RawContacts {
   addressLine1: string | null;
@@ -53,6 +100,7 @@ export interface RawVotes {
 }
 
 export interface DB {
+  AgendaItem: AgendaItem;
   RawContacts: RawContacts;
   RawVotes: RawVotes;
 }

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -28,7 +28,7 @@ export type JsonPrimitive = boolean | number | string | null;
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
-export interface AgendaItem {
+export interface RawAgendaItemConsiderations {
   /**
    * Array of addresses as strings.
    */
@@ -181,7 +181,7 @@ export interface RawVotes {
 }
 
 export interface DB {
-  AgendaItem: AgendaItem;
+  RawAgendaItemConsiderations: RawAgendaItemConsiderations;
   RawContacts: RawContacts;
   RawVotes: RawVotes;
 }

--- a/src/database/kyselyDb.ts
+++ b/src/database/kyselyDb.ts
@@ -10,7 +10,7 @@ const createDB = () =>
     dialect: new PostgresJSDialect({
       postgres: createPostgres(),
     }),
-    log: ['query', 'error'],
+    log: ['error'],
   });
 
 export const getDB = () => {

--- a/src/database/pipelines/populateAgendaItems.ts
+++ b/src/database/pipelines/populateAgendaItems.ts
@@ -3,12 +3,13 @@ import { insertAgendaItems } from '@/database/queries/agendaItems';
 
 export const populateAgendaItems = async (start: Date, end: Date) => {
   let insertedCount = BigInt(0);
-  while (start < end) {
-    const nextMonth = new Date(start);
+  let current = start;
+  while (current < end) {
+    const nextMonth = new Date(current);
     nextMonth.setMonth(nextMonth.getMonth() + 1);
-    console.log(`fetching from ${start} to ${nextMonth}`);
+    console.log(`fetching from ${current} to ${nextMonth}`);
     const agendaItems = await fetchAgendaItems({
-      start,
+      start: current,
       end: nextMonth > end ? end : nextMonth,
     });
     if (agendaItems.length > 0) {
@@ -17,9 +18,9 @@ export const populateAgendaItems = async (start: Date, end: Date) => {
     }
     console.log('inserted:', insertedCount);
 
-    start = nextMonth;
+    current = nextMonth;
 
-    if (start < end) {
+    if (current < end) {
       // wait a second before fetching again to avoid overloading the TMMIS API
       await new Promise((resolve) => setTimeout(resolve, 1000));
     }

--- a/src/database/pipelines/populateAgendaItems.ts
+++ b/src/database/pipelines/populateAgendaItems.ts
@@ -1,0 +1,27 @@
+import { fetchAgendaItems } from '@/api/agendaItem';
+import { insertAgendaItems } from '@/database/queries/agendaItems';
+
+export const populateAgendaItems = async (start: Date, end: Date) => {
+  let insertedCount = BigInt(0);
+  while (start < end) {
+    const nextMonth = new Date(start);
+    nextMonth.setMonth(nextMonth.getMonth() + 1);
+    console.log(`fetching from ${start} to ${nextMonth}`);
+    const agendaItems = await fetchAgendaItems({
+      start,
+      end: nextMonth > end ? end : nextMonth,
+    });
+    if (agendaItems.length > 0) {
+      const result = await insertAgendaItems(agendaItems);
+      insertedCount += result[0].numInsertedOrUpdatedRows ?? BigInt(0);
+    }
+    console.log('inserted:', insertedCount);
+
+    start = nextMonth;
+
+    if (start < end) {
+      // wait a second before fetching again to avoid overloading the TMMIS API
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+};

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -9,16 +9,36 @@ export const insertAgendaItems = async (items: AgendaItem[]) => {
     agendaItemAddress: agendaItemAddress as unknown as JsonArray,
   }));
 
-  // kinda convoluted upsert but it gets the job done 🤷
+  // kinda convoluted upsert but it gets the job done 🤷:
+
+  // for ez idempotent updates, it makes sense to just re-insert
+  // all the data from the previous to next month (rather than trying
+  // to compare whether the data needs updating, or risk inserting duplicate rows).
+
+  // since agenda item considerations can change over time
+  // (most notably, before/after the council actually votes on it)
+  // we need to run an ON CONFLICT clause in the INSERT query,
+  // which requires a UNIQUE constraint on the columns specified in the ON CONFLICT clause
+
+  // that UNIQUE constraint (mostly) holds over the source data set, but there were a
+  // couple instances of it not being true. in those instances, the only way to differentiate
+  // the two agenda items is using `agendaItemId`, because they have the same reference,
+  // same meeting ID, same meeting time, etc.
+
+  // the newer one (by inspection of relevant columns that might not be possible to automate) had a higher agendaItemId.
+  // if agendaItemId is tied we take the fresh values
+
+  // all of this is just best effort to get the thing off the ground and we can refine later
+
   return await getDB()
     .insertInto('RawAgendaItemConsiderations')
     .onConflict((onConflict) =>
       onConflict.columns(['reference', 'meetingId']).doUpdateSet((eb) =>
         Object.fromEntries(
           agendaItemConflictColumns
-            .filter((c) => c !== 'id')
-            .map((k) => [
-              k,
+            .filter((column) => column !== 'id')
+            .map((column) => [
+              column,
               eb
                 .case()
                 .when(
@@ -26,8 +46,8 @@ export const insertAgendaItems = async (items: AgendaItem[]) => {
                   '<=',
                   eb.ref('excluded.agendaItemId'),
                 )
-                .then(eb.ref(`excluded.${k}`))
-                .else(eb.ref(`RawAgendaItemConsiderations.${k}`))
+                .then(eb.ref(`excluded.${column}`))
+                .else(eb.ref(`RawAgendaItemConsiderations.${column}`))
                 .end(),
             ]),
         ),

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -1,0 +1,38 @@
+import { AgendaItem } from '@/api/agendaItem';
+import { getDB } from '@/database/kyselyDb';
+import { JsonArray } from '@/database/allDbTypes';
+import { agendaItemColumns } from '@/database/columns';
+
+export const insertAgendaItems = async (items: AgendaItem[]) => {
+  const asDBType = items.map(({ id: _, agendaItemAddress, ...item }) => ({
+    ...item,
+    agendaItemAddress: agendaItemAddress as unknown as JsonArray,
+  }));
+
+  // kinda convoluted upsert but it gets the job done 🤷
+  return await getDB()
+    .insertInto('AgendaItem')
+    .onConflict((onConflict) =>
+      onConflict.columns(['reference', 'meetingId']).doUpdateSet((eb) =>
+        Object.fromEntries(
+          agendaItemColumns
+            .filter((c) => c !== 'id')
+            .map((k) => [
+              k,
+              eb
+                .case()
+                .when(
+                  'AgendaItem.agendaItemId',
+                  '<=',
+                  eb.ref('excluded.agendaItemId'),
+                )
+                .then(eb.ref(`excluded.${k}`))
+                .else(eb.ref(`AgendaItem.${k}`))
+                .end(),
+            ]),
+        ),
+      ),
+    )
+    .values(asDBType)
+    .execute();
+};

--- a/src/migrations/1739821310211_AddRawAgendaItemsTable.ts
+++ b/src/migrations/1739821310211_AddRawAgendaItemsTable.ts
@@ -1,0 +1,13 @@
+import { sql, type Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE "RawAgendaItems" ("data" jsonb NOT NULL);
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DROP TABLE "RawAgendaItems";
+  `.execute(db);
+}

--- a/src/migrations/1740007960791_AddAgendaItems.ts
+++ b/src/migrations/1740007960791_AddAgendaItems.ts
@@ -2,7 +2,7 @@ import { sql, type Kysely } from 'kysely';
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
-    CREATE TABLE "AgendaItem" (
+    CREATE TABLE "RawAgendaItemConsiderations" (
       "id" uuid PRIMARY KEY DEFAULT gen_random_uuid (),
       "termId" INT NOT NULL,
       "agendaItemId" INT NOT NULL,
@@ -91,6 +91,6 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 
 export async function down(db: Kysely<unknown>): Promise<void> {
   await sql`
-    DROP TABLE "AgendaItem";
+    DROP TABLE "RawAgendaItemConsiderations";
   `.execute(db);
 }

--- a/src/migrations/1740007960791_AddAgendaItems.ts
+++ b/src/migrations/1740007960791_AddAgendaItems.ts
@@ -1,0 +1,42 @@
+import { sql, type Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE "AgendaItem" (
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid (), -- String identifier, can be UUID or similar
+      "termId" INT NOT NULL, -- TMMIS ID
+      "agendaItemId" INT NOT NULL, -- TMMIS ID
+      "councilAgendaItemId" INT NOT NULL, -- TMMIS ID
+      "decisionBodyId" INT NOT NULL, -- TMMIS ID
+      "meetingId" INT NOT NULL, -- TMMIS ID
+      "itemProcessId" INT NOT NULL, -- ???
+      "decisionBodyName" TEXT NOT NULL, -- Probably can be denormalized into decision body table.
+      "meetingDate" BIGINT NOT NULL,
+      "reference" TEXT NOT NULL,
+      "termYear" TEXT NOT NULL,
+      "agendaCd" TEXT NOT NULL,
+      "meetingNumber" TEXT NOT NULL,
+      "itemStatus" TEXT NOT NULL,
+      "agendaItemTitle" TEXT NOT NULL,
+      "agendaItemSummary" TEXT NOT NULL, -- Agenda item summary (HTML content)
+      "agendaItemRecommendation" TEXT, -- Agenda item recommendation (HTML content)
+      "decisionRecommendations" TEXT, -- Decision recommendations (HTML content)
+      "decisionAdvice" TEXT, -- Decision advice (HTML content)
+      "subjectTerms" TEXT NOT NULL,
+      "wardId" json, -- Array of ward IDs
+      "backgroundAttachmentId" json, -- Array of background attachment IDs
+      "agendaItemAddress" json, -- Array of addresses (presumably an Address object)
+      "address" json, -- Array of addresses as strings
+      "geoLocation" json, -- Array of geo-location coordinates (lat, lon)
+      "planningApplicationNumber" TEXT, -- Planning application number
+      "neighbourhoodId" json, -- Array of neighbourhood IDs
+      UNIQUE ("reference", "meetingId") -- The same agenda item reference can appear multiple times, but only once per meeting.
+    );
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    DROP TABLE "AgendaItem";
+  `.execute(db);
+}

--- a/src/migrations/1740007960791_AddAgendaItems.ts
+++ b/src/migrations/1740007960791_AddAgendaItems.ts
@@ -23,13 +23,13 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       "decisionRecommendations" TEXT,
       "decisionAdvice" TEXT,
       "subjectTerms" TEXT NOT NULL,
-      "wardId" json,
-      "backgroundAttachmentId" json,
+      "wardId" INT[],
+      "backgroundAttachmentId" INT[],
       "agendaItemAddress" json,
-      "address" json,
-      "geoLocation" json,
+      "address" TEXT[],
+      "geoLocation" TEXT[],
       "planningApplicationNumber" TEXT,
-      "neighbourhoodId" json,
+      "neighbourhoodId" INT[],
       UNIQUE ("reference", "meetingId")
     );
 
@@ -71,17 +71,21 @@ export async function up(db: Kysely<unknown>): Promise<void> {
 
     comment ON COLUMN "AgendaItem"."decisionAdvice" IS 'HTML content';
 
-    comment ON COLUMN "AgendaItem"."subjectTerms" IS 'Array of TMMIS IDs';
+    comment ON COLUMN "AgendaItem"."wardId" IS 'Array of TMMIS IDs';
+
+    comment ON COLUMN "AgendaItem"."subjectTerms" IS 'Semi-colon/comma separated string';
 
     comment ON COLUMN "AgendaItem"."backgroundAttachmentId" IS 'Array of TMMIS IDs';
 
     comment ON COLUMN "AgendaItem"."agendaItemAddress" IS 'Array of address objects, see api/agendaItem.ts';
 
-    comment ON COLUMN "AgendaItem"."address" IS 'Array of addresses as strings';
+    comment ON COLUMN "AgendaItem"."address" IS 'Array of addresses as strings.';
 
-    comment ON COLUMN "AgendaItem"."geoLocation" IS 'Array of lat/lon coordinates';
+    comment ON COLUMN "AgendaItem"."geoLocation" IS 'Array of lat/lon coordinates stored as strings.';
 
-    comment ON COLUMN "AgendaItem"."planningApplicationNumber" IS 'Array of TMMIS IDs';
+    comment ON COLUMN "AgendaItem"."planningApplicationNumber" IS 'Comma separated list of text reference numbers.';
+
+    comment ON COLUMN "AgendaItem"."neighbourhoodId" IS 'Array of TMMIS IDs';
   `.execute(db);
 }
 

--- a/src/migrations/1740007960791_AddAgendaItems.ts
+++ b/src/migrations/1740007960791_AddAgendaItems.ts
@@ -3,14 +3,14 @@ import { sql, type Kysely } from 'kysely';
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     CREATE TABLE "AgendaItem" (
-      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid (), -- String identifier, can be UUID or similar
-      "termId" INT NOT NULL, -- TMMIS ID
-      "agendaItemId" INT NOT NULL, -- TMMIS ID
-      "councilAgendaItemId" INT NOT NULL, -- TMMIS ID
-      "decisionBodyId" INT NOT NULL, -- TMMIS ID
-      "meetingId" INT NOT NULL, -- TMMIS ID
-      "itemProcessId" INT NOT NULL, -- ???
-      "decisionBodyName" TEXT NOT NULL, -- Probably can be denormalized into decision body table.
+      "id" uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+      "termId" INT NOT NULL,
+      "agendaItemId" INT NOT NULL,
+      "councilAgendaItemId" INT NOT NULL,
+      "decisionBodyId" INT NOT NULL,
+      "meetingId" INT NOT NULL,
+      "itemProcessId" INT NOT NULL,
+      "decisionBodyName" TEXT NOT NULL,
       "meetingDate" BIGINT NOT NULL,
       "reference" TEXT NOT NULL,
       "termYear" TEXT NOT NULL,
@@ -18,20 +18,70 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       "meetingNumber" TEXT NOT NULL,
       "itemStatus" TEXT NOT NULL,
       "agendaItemTitle" TEXT NOT NULL,
-      "agendaItemSummary" TEXT NOT NULL, -- Agenda item summary (HTML content)
-      "agendaItemRecommendation" TEXT, -- Agenda item recommendation (HTML content)
-      "decisionRecommendations" TEXT, -- Decision recommendations (HTML content)
-      "decisionAdvice" TEXT, -- Decision advice (HTML content)
+      "agendaItemSummary" TEXT NOT NULL,
+      "agendaItemRecommendation" TEXT,
+      "decisionRecommendations" TEXT,
+      "decisionAdvice" TEXT,
       "subjectTerms" TEXT NOT NULL,
-      "wardId" json, -- Array of ward IDs
-      "backgroundAttachmentId" json, -- Array of background attachment IDs
-      "agendaItemAddress" json, -- Array of addresses (presumably an Address object)
-      "address" json, -- Array of addresses as strings
-      "geoLocation" json, -- Array of geo-location coordinates (lat, lon)
-      "planningApplicationNumber" TEXT, -- Planning application number
-      "neighbourhoodId" json, -- Array of neighbourhood IDs
-      UNIQUE ("reference", "meetingId") -- The same agenda item reference can appear multiple times, but only once per meeting.
+      "wardId" json,
+      "backgroundAttachmentId" json,
+      "agendaItemAddress" json,
+      "address" json,
+      "geoLocation" json,
+      "planningApplicationNumber" TEXT,
+      "neighbourhoodId" json,
+      UNIQUE ("reference", "meetingId")
     );
+
+    comment ON COLUMN "AgendaItem"."id" IS 'auto-generated pkey, prefer using reference and meetingId to distinguish agenda items';
+
+    comment ON COLUMN "AgendaItem"."termId" IS 'TMMIS ID';
+
+    comment ON COLUMN "AgendaItem"."agendaItemId" IS 'TMMIS ID';
+
+    comment ON COLUMN "AgendaItem"."councilAgendaItemId" IS 'TMMIS ID';
+
+    comment ON COLUMN "AgendaItem"."decisionBodyId" IS 'TMMIS ID';
+
+    comment ON COLUMN "AgendaItem"."meetingId" IS 'TMMIS ID';
+
+    comment ON COLUMN "AgendaItem"."itemProcessId" IS 'Unknown purpose';
+
+    comment ON COLUMN "AgendaItem"."decisionBodyName" IS 'May be better to denormalize into a decision body table';
+
+    comment ON COLUMN "AgendaItem"."meetingDate" IS 'Unix timestamp in millseconds';
+
+    comment ON COLUMN "AgendaItem"."reference" IS 'Reference number, e.g. 2024.EX19.2';
+
+    comment ON COLUMN "AgendaItem"."termYear" IS 'Year of term, first component of reference';
+
+    comment ON COLUMN "AgendaItem"."agendaCd" IS 'Agenda committe descriptor, first half of second component of reference';
+
+    comment ON COLUMN "AgendaItem"."meetingNumber" IS 'Which meeting in the current year, second half of second component of reference';
+
+    comment ON COLUMN "AgendaItem"."itemStatus" IS 'An enumeration that we havent yet documented the full extend of';
+
+    comment ON COLUMN "AgendaItem"."agendaItemTitle" IS 'Plain text content';
+
+    comment ON COLUMN "AgendaItem"."agendaItemSummary" IS 'HTML content';
+
+    comment ON COLUMN "AgendaItem"."agendaItemRecommendation" IS 'HTML content';
+
+    comment ON COLUMN "AgendaItem"."decisionRecommendations" IS 'HTML content';
+
+    comment ON COLUMN "AgendaItem"."decisionAdvice" IS 'HTML content';
+
+    comment ON COLUMN "AgendaItem"."subjectTerms" IS 'Array of TMMIS IDs';
+
+    comment ON COLUMN "AgendaItem"."backgroundAttachmentId" IS 'Array of TMMIS IDs';
+
+    comment ON COLUMN "AgendaItem"."agendaItemAddress" IS 'Array of address objects, see api/agendaItem.ts';
+
+    comment ON COLUMN "AgendaItem"."address" IS 'Array of addresses as strings';
+
+    comment ON COLUMN "AgendaItem"."geoLocation" IS 'Array of lat/lon coordinates';
+
+    comment ON COLUMN "AgendaItem"."planningApplicationNumber" IS 'Array of TMMIS IDs';
   `.execute(db);
 }
 

--- a/src/migrations/1740007960791_AddAgendaItems.ts
+++ b/src/migrations/1740007960791_AddAgendaItems.ts
@@ -33,59 +33,59 @@ export async function up(db: Kysely<unknown>): Promise<void> {
       UNIQUE ("reference", "meetingId")
     );
 
-    comment ON COLUMN "AgendaItem"."id" IS 'auto-generated pkey, prefer using reference and meetingId to distinguish agenda items';
+    comment ON COLUMN "RawAgendaItemConsiderations"."id" IS 'auto-generated pkey, prefer using reference and meetingId to distinguish agenda items';
 
-    comment ON COLUMN "AgendaItem"."termId" IS 'TMMIS ID';
+    comment ON COLUMN "RawAgendaItemConsiderations"."termId" IS 'TMMIS ID';
 
-    comment ON COLUMN "AgendaItem"."agendaItemId" IS 'TMMIS ID';
+    comment ON COLUMN "RawAgendaItemConsiderations"."agendaItemId" IS 'TMMIS ID';
 
-    comment ON COLUMN "AgendaItem"."councilAgendaItemId" IS 'TMMIS ID';
+    comment ON COLUMN "RawAgendaItemConsiderations"."councilAgendaItemId" IS 'TMMIS ID';
 
-    comment ON COLUMN "AgendaItem"."decisionBodyId" IS 'TMMIS ID';
+    comment ON COLUMN "RawAgendaItemConsiderations"."decisionBodyId" IS 'TMMIS ID';
 
-    comment ON COLUMN "AgendaItem"."meetingId" IS 'TMMIS ID';
+    comment ON COLUMN "RawAgendaItemConsiderations"."meetingId" IS 'TMMIS ID';
 
-    comment ON COLUMN "AgendaItem"."itemProcessId" IS 'Unknown purpose';
+    comment ON COLUMN "RawAgendaItemConsiderations"."itemProcessId" IS 'Unknown purpose';
 
-    comment ON COLUMN "AgendaItem"."decisionBodyName" IS 'May be better to denormalize into a decision body table';
+    comment ON COLUMN "RawAgendaItemConsiderations"."decisionBodyName" IS 'May be better to denormalize into a decision body table';
 
-    comment ON COLUMN "AgendaItem"."meetingDate" IS 'Unix timestamp in millseconds';
+    comment ON COLUMN "RawAgendaItemConsiderations"."meetingDate" IS 'Unix timestamp in millseconds';
 
-    comment ON COLUMN "AgendaItem"."reference" IS 'Reference number, e.g. 2024.EX19.2';
+    comment ON COLUMN "RawAgendaItemConsiderations"."reference" IS 'Reference number, e.g. 2024.EX19.2';
 
-    comment ON COLUMN "AgendaItem"."termYear" IS 'Year of term, first component of reference';
+    comment ON COLUMN "RawAgendaItemConsiderations"."termYear" IS 'Year of term, first component of reference';
 
-    comment ON COLUMN "AgendaItem"."agendaCd" IS 'Agenda committe descriptor, first half of second component of reference';
+    comment ON COLUMN "RawAgendaItemConsiderations"."agendaCd" IS 'Agenda committe descriptor, first half of second component of reference';
 
-    comment ON COLUMN "AgendaItem"."meetingNumber" IS 'Which meeting in the current year, second half of second component of reference';
+    comment ON COLUMN "RawAgendaItemConsiderations"."meetingNumber" IS 'Which meeting in the current year, second half of second component of reference';
 
-    comment ON COLUMN "AgendaItem"."itemStatus" IS 'An enumeration that we havent yet documented the full extend of';
+    comment ON COLUMN "RawAgendaItemConsiderations"."itemStatus" IS 'An enumeration that we havent yet documented the full extend of';
 
-    comment ON COLUMN "AgendaItem"."agendaItemTitle" IS 'Plain text content';
+    comment ON COLUMN "RawAgendaItemConsiderations"."agendaItemTitle" IS 'Plain text content';
 
-    comment ON COLUMN "AgendaItem"."agendaItemSummary" IS 'HTML content';
+    comment ON COLUMN "RawAgendaItemConsiderations"."agendaItemSummary" IS 'HTML content';
 
-    comment ON COLUMN "AgendaItem"."agendaItemRecommendation" IS 'HTML content';
+    comment ON COLUMN "RawAgendaItemConsiderations"."agendaItemRecommendation" IS 'HTML content';
 
-    comment ON COLUMN "AgendaItem"."decisionRecommendations" IS 'HTML content';
+    comment ON COLUMN "RawAgendaItemConsiderations"."decisionRecommendations" IS 'HTML content';
 
-    comment ON COLUMN "AgendaItem"."decisionAdvice" IS 'HTML content';
+    comment ON COLUMN "RawAgendaItemConsiderations"."decisionAdvice" IS 'HTML content';
 
-    comment ON COLUMN "AgendaItem"."wardId" IS 'Array of TMMIS IDs';
+    comment ON COLUMN "RawAgendaItemConsiderations"."wardId" IS 'Array of TMMIS IDs';
 
-    comment ON COLUMN "AgendaItem"."subjectTerms" IS 'Semi-colon/comma separated string';
+    comment ON COLUMN "RawAgendaItemConsiderations"."subjectTerms" IS 'Semi-colon/comma separated string';
 
-    comment ON COLUMN "AgendaItem"."backgroundAttachmentId" IS 'Array of TMMIS IDs';
+    comment ON COLUMN "RawAgendaItemConsiderations"."backgroundAttachmentId" IS 'Array of TMMIS IDs';
 
-    comment ON COLUMN "AgendaItem"."agendaItemAddress" IS 'Array of address objects, see api/agendaItem.ts';
+    comment ON COLUMN "RawAgendaItemConsiderations"."agendaItemAddress" IS 'Array of address objects, see api/agendaItem.ts';
 
-    comment ON COLUMN "AgendaItem"."address" IS 'Array of addresses as strings.';
+    comment ON COLUMN "RawAgendaItemConsiderations"."address" IS 'Array of addresses as strings.';
 
-    comment ON COLUMN "AgendaItem"."geoLocation" IS 'Array of lat/lon coordinates stored as strings.';
+    comment ON COLUMN "RawAgendaItemConsiderations"."geoLocation" IS 'Array of lat/lon coordinates stored as strings.';
 
-    comment ON COLUMN "AgendaItem"."planningApplicationNumber" IS 'Comma separated list of text reference numbers.';
+    comment ON COLUMN "RawAgendaItemConsiderations"."planningApplicationNumber" IS 'Comma separated list of text reference numbers.';
 
-    comment ON COLUMN "AgendaItem"."neighbourhoodId" IS 'Array of TMMIS IDs';
+    comment ON COLUMN "RawAgendaItemConsiderations"."neighbourhoodId" IS 'Array of TMMIS IDs';
   `.execute(db);
 }
 

--- a/src/scripts/populateDatabase.ts
+++ b/src/scripts/populateDatabase.ts
@@ -1,6 +1,6 @@
 import { populateAgendaItems } from '@/database/pipelines/populateAgendaItems';
 
-const beginningOfTerm = 883630800000;
+const beginningOfTerm = 1472706000000;
 const endOfTerm = 1794632400000;
 
 await populateAgendaItems(new Date(beginningOfTerm), new Date(endOfTerm));

--- a/src/scripts/populateDatabase.ts
+++ b/src/scripts/populateDatabase.ts
@@ -1,0 +1,10 @@
+import { populateAgendaItems } from '@/database/pipelines/populateAgendaItems';
+
+const beginningOfTerm = 883630800000;
+const endOfTerm = 1794632400000;
+
+await populateAgendaItems(new Date(beginningOfTerm), new Date(endOfTerm));
+
+// for some reason the script doesn't end properly when run for a wide date range
+// so manually exit here
+process.exit(0);

--- a/src/scripts/populateDatabase.ts
+++ b/src/scripts/populateDatabase.ts
@@ -1,6 +1,6 @@
 import { populateAgendaItems } from '@/database/pipelines/populateAgendaItems';
 
-const beginningOfTerm = 1472706000000;
+const beginningOfTerm = 883630800000;
 const endOfTerm = 1794632400000;
 
 await populateAgendaItems(new Date(beginningOfTerm), new Date(endOfTerm));

--- a/src/scripts/updateDatabase.ts
+++ b/src/scripts/updateDatabase.ts
@@ -1,0 +1,12 @@
+import { populateAgendaItems } from '@/database/pipelines/populateAgendaItems';
+
+const lastMonth = new Date();
+lastMonth.setMonth(lastMonth.getMonth() - 1);
+const nextMonth = new Date();
+nextMonth.setMonth(nextMonth.getMonth() + 1);
+
+await populateAgendaItems(lastMonth, nextMonth);
+
+// for some reason the script doesn't end properly when run for a wide date range
+// so manually exit here
+process.exit(0);


### PR DESCRIPTION
- add new table `AgendaItem`
  - it has a unique constraint on `(reference, meetingId)` to support updates on conflict when refetching the same agenda items, so that updating agenda items can be idempotent
  - it is just an extremely literal translation of the data we get back from TMMIS API right now, there is no preprocessing step
- make functions for fetching agenda items from TMMIS API more flexible
- create some scripts to do initial population and ongoing updates
- schedule the update script for once an hour
- also runs the DB migrations on merge, curious people's thoughts on this or if we always want that to be manual ( :exclamation: )
  - i need to add a line so that it only runs on merge, not during the cron job

some things that are now ugh:
- the upsert is gnarly, but couldn't figure out how to simplify
  - it might end up being nicer to just pull the rows and do the deduplication logic in the typescript layer, especially once we start considering things like checking whether post-processed data needs updating, or flagging for email updates
- there is now an `AgendaItem` table, an `AgendaItems` view, and a `ProblemAgendaItems` view :thinking: 

Here is a compressed csv of all the agenda items for the current council term, so you can load it into your dev DB and start playing around right away: [currentTermAgendaItems.zip](https://github.com/user-attachments/files/18896629/currentTermAgendaItems.zip)

