### PR TITLE
Adds find your councillor section

### DIFF
--- a/src/app/councillors/page.tsx
+++ b/src/app/councillors/page.tsx
@@ -1,5 +1,6 @@
 import { createDB } from '@/database/kyselyDb';
 import Link from 'next/link';
+import { ExternalLink } from '@/components/ExternalLink';
 
 async function listCouncillors() {
   return await createDB()
@@ -20,31 +21,47 @@ async function listCouncillors() {
     .execute();
 }
 
+const wardProfilesLink =
+  'https://www.toronto.ca/city-government/data-research-maps/neighbourhoods-communities/ward-profiles/';
+
 export default async function CouncillorListPage() {
   const councillors = await listCouncillors();
   return (
     <div className="max-w-screen-sm mx-auto mt-3">
-      <h2>Toronto Councillors</h2>
-      <ul>
-        {councillors.map((councillor) => (
-          <li
-            key={councillor.contactSlug}
-            className="border border-slate-200 bg-white even:bg-slate-50 text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 even:dark:bg-slate-900 dark:text-slate-50 rounded-md mb-2"
-          >
-            <Link
-              href={`/councillors/${councillor.contactSlug}`}
-              className="p-2 flex gap-2 hover:underline"
-              prefetch={false}
+      <section className="mt-4">
+        <h2>Find Your Councillor</h2>
+        <p>
+          Not sure who your councillor is? No problem!{' '}
+          <ExternalLink href={wardProfilesLink} className="underline">
+            The ward profiles page
+          </ExternalLink>{' '}
+          can show what <em>ward</em> you are a part of. Each councillor serves
+          one ward, and all Toronto wards are listed here.
+        </p>
+      </section>
+      <section className="mt-4">
+        <h2>Current Toronto Councillors</h2>
+        <ul>
+          {councillors.map((councillor) => (
+            <li
+              key={councillor.contactSlug}
+              className="border border-slate-200 bg-white even:bg-slate-50 text-slate-950 shadow-sm dark:border-slate-800 dark:bg-slate-950 even:dark:bg-slate-900 dark:text-slate-50 rounded-md mb-2"
             >
-              <CouncillorContactPhoto photoUrl={councillor.photoUrl} />
-              <div>
-                <h3 className="text-lg">{councillor.contactName}</h3>
-                <p>{councillor.wardName}</p>
-              </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
+              <Link
+                href={`/councillors/${councillor.contactSlug}`}
+                className="p-2 flex gap-2 hover:underline"
+                prefetch={false}
+              >
+                <CouncillorContactPhoto photoUrl={councillor.photoUrl} />
+                <div>
+                  <h3 className="text-lg">{councillor.contactName}</h3>
+                  <p>{councillor.wardName}</p>
+                </div>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </section>
     </div>
   );
 }

--- a/src/components/AgendaItemLink.tsx
+++ b/src/components/AgendaItemLink.tsx
@@ -1,0 +1,12 @@
+import { ExternalLink, ExternalLinkProps } from '@/components/ExternalLink';
+
+export type AgendaItemLinkProps = Omit<ExternalLinkProps, 'href'> & {
+  agendaItemNumber: string;
+};
+
+export const AgendaItemLink = (props: AgendaItemLinkProps) => {
+  const { agendaItemNumber, ...linkProps } = props;
+  const params = new URLSearchParams({ item: agendaItemNumber });
+  const href = `https://secure.toronto.ca/council/agenda-item.do?${params}`;
+  return <ExternalLink {...linkProps} href={href} />;
+};

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type AnchorProps = JSX.IntrinsicElements['a'];
+export type ExternalLinkProps = Omit<
+  AnchorProps,
+  'target' | 'rel' | 'children'
+> & {
+  children?: React.ReactNode;
+};
+
+export const ExternalLink: React.FC<ExternalLinkProps> = (props) => (
+  <a {...props} target="_blank" rel="noopener noreferrer" />
+);


### PR DESCRIPTION
Adds a small section with a link to the toronto gov site for finding your ward.
Also adds a pair of link components for external stuff and agenda items

[Recommended PR view settings](https://github.com/civic-dashboard/civic-dashboard-web/pull/52/files?diff=split&w=1)

![image](https://github.com/user-attachments/assets/6df97a0d-bb8c-456d-b0da-efe4e669f3f0)
