### PR TITLE
feat: email development environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ EOF
 ### Initialize the database
 
 ```sh
-npm run db:start
+npm run docker:start
 npm run db:run-migrations
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,10 @@ services:
 
     volumes:
       - ${PWD}/db-data/:/var/lib/postgresql/data/
+
+  maildev:
+    image: maildev/maildev:2.2.1
+
+    ports:
+      - 1080:1080
+      - 1025:1025

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -49,5 +49,4 @@ This is (probably not, but hopefully!) all the information you need to contribut
 
 ## Emails
 
-Right now the email functionality doesn't have a good local development story. I just use the prod API key and try to make sure only my email gets into my local system 😬. Would love some help here!
-Brief research suggests a combination of [maildev](https://github.com/maildev/maildev?tab=readme-ov-file) and [nodemailer](https://github.com/nodemailer/nodemailer) could do the trick.
+We use [maildev](https://github.com/maildev/maildev) to preview emails in development. Make sure you've started your docker containers with `npm run docker:start`, and navigate to `localhost:1080` in your browser. All emails that are sent from the app in development mode will show up in this inbox!

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -15,7 +15,9 @@ This file comprehensively lists the dependencies of the project, and why they ar
 
 ## Emails
 
-- `resend`, `react-email`, and `@react-email/components` are used for sending emails
+- `react-email`, and `@react-email/components` are used for constructing email content.
+- `resend` is our prod email provider.
+- `nodemailer` and `maildev` are used for previewing emails in development.
 
 ## UI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@types/hash-sum": "1.0.2",
         "@types/mark.js": "^8.11.12",
         "@types/node": "^20",
+        "@types/nodemailer": "^6.4.17",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "eslint": "^8.57.1",
@@ -51,6 +52,7 @@
         "eslint-plugin-sql": "^3.2.1",
         "kysely-codegen": "^0.17.0",
         "kysely-ctl": "^0.10.1",
+        "nodemailer": "^6.10.0",
         "pg": "^8.13.2",
         "postcss": "^8",
         "prettier": "3.4.2",
@@ -12809,6 +12811,16 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.14",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
@@ -18333,6 +18345,16 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "node_modules/nodemailer": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
+      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "dev": true,
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/nopt": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
@@ -23013,6 +23035,21 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/react-email/node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.23",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.23.tgz",
+      "integrity": "sha512-zfHZOGguFCqAJ7zldTKg4tJHPJyJCOFhpoJcVxKL9BSUHScVDnMdDuOU1zPPGdOzr/GWxbhYTjyiEgLEpAoFPA==",
+      "cpu": [
+        "ia32"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "db:create-migration": "kysely migrate:make",
     "db:list-migrations": "kysely migrate:list",
     "db:run-migrations": "kysely migrate:latest",
-    "db:start": "docker compose up --detach",
-    "db:stop": "docker compose stop"
+    "db:start": "docker compose up --detach database",
+    "db:stop": "docker compose stop database",
+    "docker:start": "docker compose up --detach",
+    "docker:stop": "docker compose stop"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.1.4",
@@ -54,6 +56,7 @@
     "@types/hash-sum": "1.0.2",
     "@types/mark.js": "^8.11.12",
     "@types/node": "^20",
+    "@types/nodemailer": "^6.4.17",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "eslint": "^8.57.1",
@@ -64,6 +67,7 @@
     "eslint-plugin-sql": "^3.2.1",
     "kysely-codegen": "^0.17.0",
     "kysely-ctl": "^0.10.1",
+    "nodemailer": "^6.10.0",
     "pg": "^8.13.2",
     "postcss": "^8",
     "prettier": "3.4.2",

--- a/src/backend/emails/sendEmail.ts
+++ b/src/backend/emails/sendEmail.ts
@@ -1,8 +1,28 @@
-import { CreateEmailOptions, Resend } from 'resend';
+import { Resend } from 'resend';
+import { render } from '@react-email/components';
 
 export const resend = new Resend(process.env.RESEND_API_KEY);
 
-export async function sendEmail(options: CreateEmailOptions) {
+type Options = {
+  from: string;
+  subject: string;
+  to: string;
+  react: React.ReactElement;
+};
+export async function sendEmail(options: Options) {
+  if (process.env.NODE_ENV !== 'production') {
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+    const nodemailer = await import('nodemailer');
+    const transport = nodemailer.createTransport({
+      host: 'localhost',
+      port: 1025,
+    });
+
+    const { react, ...emailOptions } = options;
+    await transport.sendMail({ ...emailOptions, html: await render(react) });
+    return;
+  }
+
   const response = await resend.emails.send(options);
 
   if (response.error) {

--- a/src/backend/emails/sendEmail.ts
+++ b/src/backend/emails/sendEmail.ts
@@ -6,7 +6,7 @@ export const resend = new Resend(process.env.RESEND_API_KEY);
 type Options = {
   from: string;
   subject: string;
-  to: string;
+  to: string | string[];
   react: React.ReactElement;
 };
 export async function sendEmail(options: Options) {


### PR DESCRIPTION
allows previewing emails in development environment without sending them through our prod email provider.

adds a `maildev` service to our docker compose file, and uses `nodemailer` in development environments to send emails to that service.

fixes #64 