### PR TITLE
Use shorter meta description

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,7 @@ const geistMono = localFont({
 export const metadata: Metadata = {
   title: 'Civic Dashboard',
   description:
-    'Accessing Toronto City Council decisions shouldn’t be difficult, but today it is. The Civic Dashboard simplifies this process, letting Toronto residents easily search what their councillors are voting on, how they voted, and the history of decisions on key topics. Stay informed and engaged with your local government like never before.',
+    "Toronto City Council shouldn't feel complicated. We make it easy for Toronto residents to track councillor votes and get involved in local decisions.",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Fixes #123 

This PR updates the meta description (seen by search engines and other bots) to the new shorter text suggested on [Slack](https://civictechto.slack.com/archives/C06KU3DHEKV/p1745714663982079?thread_ts=1745620028.525759&cid=C06KU3DHEKV). This is more in line with the recommended character length for this bit of text.
