### PR TITLE
lint: allow quotes in content

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,21 @@
       "error", 
       {"name": "umami", "message": "Use logAnalytics instead."}
     ],
+    "react/no-unescaped-entities": [
+      "error",
+      {
+        "forbid": [
+          {
+            "char": ">",
+            "alternatives": ["&gt;"]
+          }, 
+          {
+            "char": "}",
+            "alternatives": ["&#125;"]
+          }
+        ]
+      }
+    ],
     "no-restricted-imports": [
       "error",
       {

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -15,7 +15,7 @@ export default function About() {
           <section className="mb-16">
             <h2 className="text-3xl font-semibold mb-6">Why We Exist</h2>
             <p className="mb-6">
-              In brief, we&apos;re regular Torontonians who believe:
+              In brief, we're regular Torontonians who believe:
             </p>
             <ul className="space-y-4 mb-8">
               <li>
@@ -24,8 +24,8 @@ export default function About() {
                 about it should be universally accessible.
               </li>
               <li>
-                A democracy is only democratic if it&apos;s accessible, and ours
-                currently isn&apos;t for the vast majority of its residents.
+                A democracy is only democratic if it's accessible, and ours
+                currently isn't for the vast majority of its residents.
               </li>
               <li>
                 A more engaged democracy is a more representative and effective
@@ -41,14 +41,14 @@ export default function About() {
             </ul>
             <div className="space-y-6">
               <p>
-                We think that people care a lot, they just aren&apos;t given the
+                We think that people care a lot, they just aren't given the
                 right tools to translate that passion into democratic
                 engagement. We believe a more accessible, lower-friction
                 democracy will be adopted more widely, will be more
-                representative of our city&apos;s population and its desires,
-                will be engaged with far more often than just during elections,
-                and will contribute to a more bought-in, people-centric, and
-                flourishing city - and that that&apos;s worth working on.
+                representative of our city's population and its desires, will be
+                engaged with far more often than just during elections, and will
+                contribute to a more bought-in, people-centric, and flourishing
+                city - and that that's worth working on.
               </p>
               <p>
                 Lastly, we believe that a small group of humble, ambitious,
@@ -77,21 +77,21 @@ export default function About() {
             </p>
             <ul className="space-y-4 mb-8">
               <li>
-                We&apos;re not for profit - no one is making money off of this,
-                and no one ever will. This is made by people who care and come
+                We're not for profit - no one is making money off of this, and
+                no one ever will. This is made by people who care and come
                 together, so that people can more easily care and come together,
                 for the benefit of all.
               </li>
               <li>
                 We keep costs low, we use volunteer labour, and we are
                 thoughtful and self-critical about the pressures and incentives
-                we exist under. We&apos;re building this as long-term critical
-                public infrastructure - thoughtfully, prioritizing public input
-                and stability, and without profit in mind.
+                we exist under. We're building this as long-term critical public
+                infrastructure - thoughtfully, prioritizing public input and
+                stability, and without profit in mind.
               </li>
               <li>
-                We&apos;re 100% volunteer driven - and we welcome all
-                contributions! Democracy&apos;s not gonna upgrade itself.
+                We're 100% volunteer driven - and we welcome all contributions!
+                Democracy's not gonna upgrade itself.
               </li>
             </ul>
             <div className="space-y-6">
@@ -103,9 +103,9 @@ export default function About() {
                 .
               </p>
               <p>
-                We&apos;re an open organization - that means we default to
-                showing everyone everything, including our works in progress! As
-                a start, you can find:
+                We're an open organization - that means we default to showing
+                everyone everything, including our works in progress! As a
+                start, you can find:
               </p>
               <ul className="space-y-4 mb-8">
                 <li>
@@ -113,7 +113,7 @@ export default function About() {
                     href="https://docs.google.com/document/d/1o00Ce6k4YUFsKFju1BUJodRgOjXyaImXMHkdemTkSRA/edit?tab=t.0"
                     className="classic-link"
                   >
-                    Our organization&apos;s core documents and directory
+                    Our organization's core documents and directory
                   </ExternalLink>
                 </li>
                 <li>
@@ -135,9 +135,8 @@ export default function About() {
                 </li>
               </ul>
               <p>
-                If there&apos;s something you want to know about our
-                organization or work but can&apos;t see below, it&apos;s due to
-                one of:
+                If there's something you want to know about our organization or
+                work but can't see below, it's due to one of:
               </p>
               <ul className="space-y-4 mb-8">
                 <li>The ever-present gap between documentation and reality</li>
@@ -185,10 +184,10 @@ export default function About() {
                   Civic Tech Toronto
                 </ExternalLink>{' '}
                 - a completely volunteer-run weekly civic tech lecture and work
-                session series that hasn&apos;t missed a Tuesday in almost a
-                decade! If you&apos;re interested in learning more about
-                projects like this one, the civic technology space, and meeting
-                folks passionate about it in Toronto, come to one of the{' '}
+                session series that hasn't missed a Tuesday in almost a decade!
+                If you're interested in learning more about projects like this
+                one, the civic technology space, and meeting folks passionate
+                about it in Toronto, come to one of the{' '}
                 <ExternalLink
                   href="https://guild.host/ctto/events"
                   className="classic-link"

--- a/src/app/actions/item/[reference]/page.tsx
+++ b/src/app/actions/item/[reference]/page.tsx
@@ -35,7 +35,7 @@ export default async function AgendaItemPage({ params }: Props) {
   if (!agendaItem) {
     return (
       <main className="p-12 min-h-[500]">
-        <h1>We couldn&apos;t find that agenda item</h1>
+        <h1>We couldn't find that agenda item</h1>
       </main>
     );
   }

--- a/src/app/feedback/page.tsx
+++ b/src/app/feedback/page.tsx
@@ -12,13 +12,13 @@ export default function ShareThoughtsPage() {
       <section className="mb-16">
         <h1 className="text-4xl font-bold">Share Your Thoughts</h1>
         <p className="mt-4">
-          We’d love to hear any thoughts you&apos;re willing to share! Know that
-          we read every piece of feedback, and that it is this project&apos;s
-          guiding light.
+          We’d love to hear any thoughts you're willing to share! Know that we
+          read every piece of feedback, and that it is this project's guiding
+          light.
         </p>
         <p className="mt-4">
-          All we ask is that you be respectful in your communication. It&apos;s
-          100% ok if you have strong negative feelings about any aspect of the
+          All we ask is that you be respectful in your communication. It's 100%
+          ok if you have strong negative feelings about any aspect of the
           project - we want to hear them! That said, everyone working on this
           project is a passion-driven volunteer who is truly doing their best -
           please keep this in mind as you share your thoughts 😊
@@ -88,7 +88,7 @@ export default function ShareThoughtsPage() {
             >
               sign up for our newsletter
             </a>{' '}
-            to know when we&apos;re asking for feedback!
+            to know when we're asking for feedback!
           </li>
           <li>
             <strong>Meet Us</strong> - Come to a{' '}
@@ -99,8 +99,8 @@ export default function ShareThoughtsPage() {
               Civic Tech Toronto hacknight
             </ExternalLink>
             . These happen every Tuesday 7-9pm, both in-person somewhere in
-            Toronto and over Zoom! They&apos;re full of friendly people working
-            to make our city better and having fun doing it 😊.
+            Toronto and over Zoom! They're full of friendly people working to
+            make our city better and having fun doing it 😊.
           </li>
         </ul>
       </section>

--- a/src/app/how-council-works/page.tsx
+++ b/src/app/how-council-works/page.tsx
@@ -119,10 +119,10 @@ export default function HowCouncilWorks() {
             >
               City Council
             </Tooltip>{' '}
-            is the decision-making body for the City of Toronto. It&apos;s made
-            up of elected officials who vote on policies, laws, and initiatives
-            that impact the city. These decisions affect everything from local
-            parks to public transit and housing. The process used to make these
+            is the decision-making body for the City of Toronto. It's made up of
+            elected officials who vote on policies, laws, and initiatives that
+            impact the city. These decisions affect everything from local parks
+            to public transit and housing. The process used to make these
             decisions follows three key steps.
           </SectionText>
           <ProcessImage src={imageData.toronto.src} />
@@ -158,7 +158,7 @@ export default function HowCouncilWorks() {
           <SectionHeading>The Three-Step City Council Process</SectionHeading>
 
           <SectionText>
-            Before we dive into the process, let&apos;s define what City Council
+            Before we dive into the process, let's define what City Council
             works on. An{' '}
             <Tooltip
               tooltipContent={tooltips.item.content}
@@ -179,8 +179,8 @@ export default function HowCouncilWorks() {
             recommendations.
             <br />
             <br />
-            Now, let&apos;s follow how an item moves through City Council and
-            how you can engage with it along the way.
+            Now, let's follow how an item moves through City Council and how you
+            can engage with it along the way.
           </SectionText>
         </div>
         {/* Staff Stage */}
@@ -220,11 +220,11 @@ export default function HowCouncilWorks() {
             >
               committee
             </Tooltip>
-            , a smaller group of council members. Committees review the
-            staff&apos;s recommendations, provide feedback, suggest changes, and
-            ask critical questions to ensure the proposals are well thought out.
-            While committees don&apos;t make final decisions, they refine the
-            item and send it to the full Council for voting.
+            , a smaller group of council members. Committees review the staff's
+            recommendations, provide feedback, suggest changes, and ask critical
+            questions to ensure the proposals are well thought out. While
+            committees don't make final decisions, they refine the item and send
+            it to the full Council for voting.
             <br />
             <br />
             This stage also provides an opportunity for public deputations,

--- a/src/app/join/page.tsx
+++ b/src/app/join/page.tsx
@@ -5,8 +5,8 @@ export default function JoinPage() {
       <section className="mb-16">
         <h1 className="text-4xl font-bold text-gray-900">Join The Team!</h1>
         <p className="mt-4 text-xl text-gray-700">
-          We&apos;re a completely volunteer-run team - meaning that all of us
-          were once where you are, just hearing about this project for the first
+          We're a completely volunteer-run team - meaning that all of us were
+          once where you are, just hearing about this project for the first
           time! No matter who you are, you can contribute to this project.
         </p>
       </section>
@@ -28,10 +28,10 @@ export default function JoinPage() {
           </p>
 
           <p>
-            If you&apos;re just someone who believes that we can more
-            peacefully, thoughtfully, creatively, and sustainably coexist,
-            believes this project could be a way to help do that, and wants to
-            contribute? We need you.
+            If you're just someone who believes that we can more peacefully,
+            thoughtfully, creatively, and sustainably coexist, believes this
+            project could be a way to help do that, and wants to contribute? We
+            need you.
           </p>
         </div>
       </section>
@@ -48,14 +48,13 @@ export default function JoinPage() {
           <li>
             <strong>Autonomy</strong> - you choose what you work on! Put your
             name down for tasks, and feel free to add tasks if you want to work
-            on something that isn&apos;t currently there. We trust your
-            intelligence!
+            on something that isn't currently there. We trust your intelligence!
           </li>
           <li>
             <strong>Ownership</strong> - our only rule is that if you recognize
-            you can&apos;t do something you have your name on, that&apos;s
-            perfectly ok! Just let us know and we&apos;ll either get you help or
-            find someone who can.
+            you can't do something you have your name on, that's perfectly ok!
+            Just let us know and we'll either get you help or find someone who
+            can.
           </li>
           <li>
             <strong>Longevity</strong> - do work such that others can pick up
@@ -89,10 +88,10 @@ export default function JoinPage() {
           </p>
 
           <p className="text-gray-700">
-            We&apos;ve had folks contribute continuously from the start of the
-            project, we&apos;ve had folks come in and out, we&apos;ve had folks
-            contribute intensely for a short stretch, and we&apos;re
-            accommodating of and deeply grateful for it all.
+            We've had folks contribute continuously from the start of the
+            project, we've had folks come in and out, we've had folks contribute
+            intensely for a short stretch, and we're accommodating of and deeply
+            grateful for it all.
           </p>
         </div>
       </section>
@@ -113,8 +112,8 @@ export default function JoinPage() {
             >
               Onboarding document
             </a>{' '}
-            to get a sense of what we&apos;re building, where we&apos;re aiming,
-            and how we&apos;re collaborating to get there.
+            to get a sense of what we're building, where we're aiming, and how
+            we're collaborating to get there.
           </li>
           <li>
             <strong>Email</strong> - Shoot an email to{' '}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -20,7 +20,7 @@ export default function Home() {
         <div className="relative max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 h-full flex items-center">
           <div className="text-white space-y-6">
             <h1 className="text-5xl sm:text-6xl md:text-7xl font-bold tracking-tight mb-4 animate-fade-in">
-              Know what&apos;s happening in{' '}
+              Know what's happening in{' '}
               <span className="text-transparent bg-clip-text bg-gradient-to-r from-blue-400 to-purple-400">
                 Toronto City Council
               </span>
@@ -54,7 +54,7 @@ export default function Home() {
               The Civic Dashboard Project
             </h2>
             <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
-              It shouldn&apos;t take 3 hours and a political science degree to
+              It shouldn't take 3 hours and a political science degree to
               understand City Council and how to meaningfully engage with it. We
               make it take a few minutes.
             </p>
@@ -112,7 +112,7 @@ export default function Home() {
               Join us in making democracy more accessible
             </h2>
             <p className="text-white/90 text-lg mb-8">
-              We&apos;re regular, passionate Torontonians building a better city
+              We're regular, passionate Torontonians building a better city
               together
             </p>
             <a

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -14,8 +14,8 @@ export default function Privacy() {
           <p>
             We strive to keep this page up to date with a simple explanation of
             what data about you we store or send to 3rd parties as part of
-            operating Civic Dashboard! This project is nascent, and we&apos;re
-            aware we need to flesh this out more.{' '}
+            operating Civic Dashboard! This project is nascent, and we're aware
+            we need to flesh this out more.{' '}
             <a href="/feedback">Let us know how we can do better! </a>
           </p>
 
@@ -47,8 +47,8 @@ export default function Privacy() {
           <p>
             That means the pages you view and significant actions you take on
             the website (but NOT any content you submit to the website) will be
-            stored alongside an identifier that can&apos;t be linked back to
-            you, and which is changed every month.
+            stored alongside an identifier that can't be linked back to you, and
+            which is changed every month.
           </p>
 
           <p>

--- a/src/app/subscription/[token]/page.tsx
+++ b/src/app/subscription/[token]/page.tsx
@@ -17,7 +17,7 @@ export default async function SubscriptionsPage({ params }: Props) {
   if (!subscriptionInfo) {
     return (
       <main className="p-12 min-h-[500]">
-        <h1>We couldn&apos;t find that subscription</h1>
+        <h1>We couldn't find that subscription</h1>
       </main>
     );
   }


### PR DESCRIPTION
this PR relaxes the eslint rule [`react/no-unescaped-entites`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unescaped-entities.md) to only forbid `>` and `}`. it's meant to help with situations where you've accidentally closed an HTML tag early, but the trade-off with having `&apos;` all over our content on a content-heavy site was not feeling worth it to me. let me know if anyone disagrees!