### PR TITLE
Add error handling to Public Consultation page

### DIFF
--- a/src/components/PublicConsultationList.tsx
+++ b/src/components/PublicConsultationList.tsx
@@ -6,14 +6,28 @@ const isUpcoming = (event: EventData) => {
 };
 
 export async function PublicConsultationList() {
-  const events = await fetchPublicConsultations();
+  let events: EventData[] = [];
+
+  try {
+    events = await fetchPublicConsultations();
+  } catch (err) {
+    console.log('Could not fetch public consultation data', err);
+  }
+
   return (
     <div className="flex-col space-y-4 p-4 max-w-[1000px]">
-      {events?.map(
-        (event) =>
-          isUpcoming(event) && (
-            <PublicConsultationCard key={event.calEvent.recId} event={event} />
-          ),
+      {events.length ? (
+        events.map(
+          (event) =>
+            isUpcoming(event) && (
+              <PublicConsultationCard
+                key={event.calEvent.recId}
+                event={event}
+              />
+            ),
+        )
+      ) : (
+        <p>No events found</p>
       )}
     </div>
   );


### PR DESCRIPTION
While working on #175, the CI could not build the site -- it seemed to break on the public consultation page, because the fetched data was invalid JSON. However, the page loaded fine when run locally, so I assume that the API just didn't like the CI fetching from it.

This PR adds some error handling to the public consultation list so it doesn't crash if it fails to fetch data.