### PR TITLE
Explode 💣 & preen 🧼✨agenda items subject terms

### DIFF
--- a/src/api/agendaItem.ts
+++ b/src/api/agendaItem.ts
@@ -61,6 +61,13 @@ export interface TMMISAgendaItem {
   neighbourhoodId?: number[];
 }
 
+export interface AgendaItemSubjectTerm {
+  agendaItemId: number;
+  subjectTermRaw: string; // Term exploded/unbracketed from subjectTerms without special chars replaced (e.g. "&" -X-> "and")
+  subjectTermNormalized: string; // Term exploded/unbracketed from subjectTerms wit special chars replaced (e.g. "&" -> "and")
+  subjectTermSlug: string; // Slugged term of normalized subjectTerm for potentially index-friendly db queries
+}
+
 type AgendaItemFetchOptions = {
   start: Date;
   end: Date;

--- a/src/api/agendaItem.ts
+++ b/src/api/agendaItem.ts
@@ -62,7 +62,8 @@ export interface TMMISAgendaItem {
 }
 
 export interface AgendaItemSubjectTerm {
-  id: string; // Unique identifier for the subject term
+  reference: string; // Unique identifier for the subject term
+  meetingId: number; // Unique identifier for the subject term
   agendaItemId: number; // Not unique
   subjectTermRaw: string; // Term exploded/unbracketed from subjectTerms without special chars replaced (e.g. "&" -X-> "and")
   subjectTermNormalized: string; // Term exploded/unbracketed from subjectTerms wit special chars replaced (e.g. "&" -> "and")

--- a/src/api/agendaItem.ts
+++ b/src/api/agendaItem.ts
@@ -62,8 +62,6 @@ export interface TMMISAgendaItem {
 }
 
 export interface AgendaItemSubjectTerm {
-  reference: string; // Unique identifier for the subject term
-  meetingId: number; // Unique identifier for the subject term
   agendaItemId: number; // Not unique
   subjectTermRaw: string; // Term exploded/unbracketed from subjectTerms without special chars replaced (e.g. "&" -X-> "and")
   subjectTermNormalized: string; // Term exploded/unbracketed from subjectTerms wit special chars replaced (e.g. "&" -> "and")

--- a/src/api/agendaItem.ts
+++ b/src/api/agendaItem.ts
@@ -62,7 +62,8 @@ export interface TMMISAgendaItem {
 }
 
 export interface AgendaItemSubjectTerm {
-  agendaItemId: number;
+  id: string; // Unique identifier for the subject term
+  agendaItemId: number; // Not unique
   subjectTermRaw: string; // Term exploded/unbracketed from subjectTerms without special chars replaced (e.g. "&" -X-> "and")
   subjectTermNormalized: string; // Term exploded/unbracketed from subjectTerms wit special chars replaced (e.g. "&" -> "and")
   subjectTermSlug: string; // Slugged term of normalized subjectTerm for potentially index-friendly db queries

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -30,8 +30,6 @@ export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
 export interface AgendaItemSubjectTerms {
   agendaItemId: number;
-  meetingId: number;
-  reference: string;
   subjectTermNormalized: string;
   subjectTermRaw: string;
   subjectTermSlug: string;

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -28,6 +28,14 @@ export type JsonPrimitive = boolean | number | string | null;
 
 export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
+export interface AgendaItemSubjectTerms {
+  agendaItemId: number;
+  id: string;
+  subjectTermNormalized: string;
+  subjectTermRaw: string;
+  subjectTermSlug: string;
+}
+
 export interface AiSummaries {
   agendaItemNumber: string;
   summary: string;
@@ -242,6 +250,7 @@ export interface TagCategories {
 }
 
 export interface DB {
+  AgendaItemSubjectTerms: AgendaItemSubjectTerms;
   AiSummaries: AiSummaries;
   RawAgendaItemConsiderations: RawAgendaItemConsiderations;
   RawAgendaItems: RawAgendaItems;

--- a/src/database/generatedDbTypes.d.ts
+++ b/src/database/generatedDbTypes.d.ts
@@ -30,7 +30,8 @@ export type JsonValue = JsonArray | JsonObject | JsonPrimitive;
 
 export interface AgendaItemSubjectTerms {
   agendaItemId: number;
-  id: string;
+  meetingId: number;
+  reference: string;
   subjectTermNormalized: string;
   subjectTermRaw: string;
   subjectTermSlug: string;

--- a/src/database/pipelines/populateAgendaItems.ts
+++ b/src/database/pipelines/populateAgendaItems.ts
@@ -17,6 +17,7 @@ const normalizeSubjectTerms = (
 ): AgendaItemSubjectTerm[] => {
   return agendaItems.flatMap((item) => {
     return processSubjectTerms(item.subjectTerms).map((term) => ({
+      id: item.id,
       agendaItemId: item.agendaItemId,
       subjectTermRaw: term.raw,
       subjectTermNormalized: term.normalized,

--- a/src/database/pipelines/populateAgendaItems.ts
+++ b/src/database/pipelines/populateAgendaItems.ts
@@ -28,7 +28,7 @@ export const populateAgendaItems = async (
        * Consider incorporating into cleanAgendaItem function in @/api/agendaItem if normalized subject terms are to be stored in table RawAgendaItemConsiderations
        * This is a separate step to avoid modifying the original RawAgendaItemConsiderations, a few options brainstormed below (open to suggestions!):
        * -> Option 1 [selected]: Normalize in the pipeline applying only on new incoming data and apply to stored data in a separate job
-       * -> Option 2: Normalize after insertion in a separate job for the sake of data synchronization
+       * -> Option 2 (see src/scripts/processAgendaItemSubjectTerms.ts): Normalize after insertion in a separate job for the sake of data synchronization
        */
       const normalizedSubjectTerms = normalizeSubjectTerms(agendaItems);
       console.log(

--- a/src/database/pipelines/textParseUtils.ts
+++ b/src/database/pipelines/textParseUtils.ts
@@ -90,7 +90,6 @@ function normalizeTextCharsSymbols(text: string): string {
     $: 'dollar',
     '%': 'percent',
     '§': 'section',
-    '/': 'or',
     '#': 'number',
     '-': ' ', // Not sure if this is desirable
     _: ' ', // Not sure if this is desirable

--- a/src/database/pipelines/textParseUtils.ts
+++ b/src/database/pipelines/textParseUtils.ts
@@ -78,3 +78,81 @@ function getCleanCouncillorSlug(approximateName: string) {
     );
   return toSlug(cleanName);
 }
+
+// Either leave here or place in @/logic/sanitize
+function normalizeTextCharsSymbols(text: string): string {
+  const replacements: Record<string, string> = {
+    '&': 'and',
+    '@': 'at',
+    '€': 'euro',
+    '£': 'pound',
+    '°': 'degree',
+    $: 'dollar',
+    '%': 'percent',
+    '§': 'section',
+    '/': 'or',
+    '#': 'number',
+    '-': ' ', // Not sure if this is desirable
+    _: ' ', // Not sure if this is desirable
+  };
+
+  const regex = new RegExp(Object.keys(replacements).join('|'), 'g');
+
+  const normalizedText = text
+    .replace(regex, (match) => replacements[match] || match)
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return normalizedText.length > 0 ? normalizedText : text;
+}
+
+function extractBracketTerms(text: string): string[] {
+  // Match text wrapped in brackets:(), {}, []
+  const matches = [...text.matchAll(/[\(\[\{]([^)\]\}]*)[\)\]\}]/g)];
+  // Remove bracketed terms, returns "" if only contains bracketed terms
+  const unbracketedTerms = text
+    .replace(/[\(\[\{][^)\]\}]*[\)\]\}]/g, '')
+    .trim();
+
+  // Get bracketed terms and trim spaces
+  const extractedTerms = matches
+    .map((match) => match[1].trim())
+    .filter((term) => term.length > 0);
+
+  // Remove brackets
+  const cleanedTerms =
+    unbracketedTerms.length > 0
+      ? [unbracketedTerms, ...extractedTerms]
+      : extractedTerms;
+
+  return cleanedTerms;
+}
+
+function explodeSubjectTerms(subjectTerms: string): string[] {
+  // Split on semicolons wrapped in brackets
+  return subjectTerms
+    .split(/[;,]/)
+    .map((term) => term.trim())
+    .filter((term) => term.length > 0);
+}
+
+export function processSubjectTerms(
+  subjectTerms: string,
+): { raw: string; normalized: string }[] {
+  if (subjectTerms.length === 0)
+    throw new Error(`Can't process empty subject terms`);
+
+  // Explode on semicolons and commas
+  const explodeTerms: string[] = explodeSubjectTerms(subjectTerms);
+
+  // Explode terms contain in brackets
+  const refinedTerms: string[] = explodeTerms.flatMap((term) =>
+    extractBracketTerms(term),
+  );
+
+  // Return both raw and normalized term
+  return refinedTerms.map((term) => ({
+    raw: term,
+    normalized: normalizeTextCharsSymbols(term),
+  }));
+}

--- a/src/database/pipelines/textParseUtils.ts
+++ b/src/database/pipelines/textParseUtils.ts
@@ -128,7 +128,7 @@ function extractBracketTerms(text: string): string[] {
 function explodeSubjectTerms(subjectTerms: string): string[] {
   // Split on semicolons wrapped in brackets
   return subjectTerms
-    .split(/[;,]/)
+    .split(/[;,]/g)
     .map((term) => term.trim())
     .filter((term) => term.length > 0);
 }

--- a/src/database/pipelines/textParseUtils.ts
+++ b/src/database/pipelines/textParseUtils.ts
@@ -108,11 +108,9 @@ function normalizeTextCharsSymbols(text: string): string {
 
 function extractBracketTerms(text: string): string[] {
   // Match text wrapped in brackets:(), {}, []
-  const matches = [...text.matchAll(/[\(\[\{]([^)\]\}]*)[\)\]\}]/g)];
+  const matches = [...text.matchAll(/[([{]([^)\]}]*)[)\]}]/g)];
   // Remove bracketed terms, returns "" if only contains bracketed terms
-  const unbracketedTerms = text
-    .replace(/[\(\[\{][^)\]\}]*[\)\]\}]/g, '')
-    .trim();
+  const unbracketedTerms = text.replace(/[([{][^)\]}]*[)\]}]/g, '').trim();
 
   // Get bracketed terms and trim spaces
   const extractedTerms = matches

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -43,7 +43,7 @@ export interface AgendaItem {
 
 type AgendaItemForSubjectTerm = Pick<
   AgendaItem,
-  'reference' | 'meetingId' | 'agendaItemId' | 'subjectTerms'
+  'agendaItemId' | 'subjectTerms'
 >;
 
 const cleanAgendaItem = <
@@ -127,15 +127,11 @@ export const insertAgendaItemSubjectTerms = async (
       .values(
         items.map(
           ({
-            reference,
-            meetingId,
             agendaItemId,
             subjectTermRaw,
             subjectTermNormalized,
             subjectTermSlug,
           }) => ({
-            reference,
-            meetingId,
             agendaItemId,
             subjectTermRaw,
             subjectTermNormalized,
@@ -156,8 +152,6 @@ export function normalizeSubjectTerms(
 ): AgendaItemSubjectTerm[] {
   return agendaItems.flatMap((item) => {
     return processSubjectTerms(item.subjectTerms).map((term) => ({
-      reference: item.reference,
-      meetingId: item.meetingId,
       agendaItemId: item.agendaItemId,
       subjectTermRaw: term.raw,
       subjectTermNormalized: term.normalized,

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -169,7 +169,13 @@ export function normalizeSubjectTerms(
 export const processAgendaItemSubjectTerms = async (db: Kysely<DB>) => {
   // This function processes all the subject terms from the agenda items
   // and inserts them into the database table AgendaItemSubjectTerms.
-
+  // Delete all rows in AgendaItemSubjectTerms
+  const deleteResult = await db
+    .deleteFrom('AgendaItemSubjectTerms')
+    .executeTakeFirst();
+  const deletedRows = deleteResult.numDeletedRows ?? 0;
+  // So far number of deleted row is consistent with number of rows in table
+  console.log(`Deleted ${deletedRows} rows from AgendaItemSubjectTerms.`);
   // Fetch agenda items
   const agendaItems = await db
     .selectFrom('RawAgendaItemConsiderations')
@@ -181,6 +187,7 @@ export const processAgendaItemSubjectTerms = async (db: Kysely<DB>) => {
   const normalizedSubjectTerms = normalizeSubjectTerms(agendaItems);
   if (normalizedSubjectTerms.length > 0) {
     await insertAgendaItemSubjectTerms(db, normalizedSubjectTerms);
+    // TODO: determine exactly how many rows of data were inserted, normalizedSubjectTerms.length does not reflect how many rows were inserted (could be less)
     console.log(
       `Processed and inserted ${normalizedSubjectTerms.length} subject terms for agenda items.`,
     );

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -116,15 +116,17 @@ export const insertAgendaItemSubjectTerms = async (
 ) => {
   await db.transaction().execute(async (trx) => {
     await trx
-      .insertInto('AgendaItemSubjectTerm')
+      .insertInto('AgendaItemSubjectTerms')
       .values(
         items.map(
           ({
+            id,
             agendaItemId,
             subjectTermRaw,
             subjectTermNormalized,
             subjectTermSlug,
           }) => ({
+            id,
             agendaItemId,
             subjectTermRaw,
             subjectTermNormalized,
@@ -133,7 +135,7 @@ export const insertAgendaItemSubjectTerms = async (
         ),
       )
       .onConflict((oc) =>
-        oc.columns(['agendaItemId', 'subjectTermSlug']).merge(),
+        oc.columns(['agendaItemId', 'subjectTermSlug']).doNothing(),
       )
       .execute();
     console.log(`Inserted/updated ${items.length} agenda item subject terms`);

--- a/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
+++ b/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
@@ -1,0 +1,21 @@
+import { sql, type Kysely } from 'kysely';
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+	CREATE TABLE "AgendaItemSubjectTerms" (
+	"agendaItemId" INTEGER NOT NULL,
+	"subjectTermRaw" TEXT NOT NULL,
+	"subjectTermNormalized" TEXT NOT NULL,
+	"subjectTermSlug" TEXT NOT NULL,
+	PRIMARY KEY ("agendaItemId", "subjectTermSlug"));
+	FOREIGN KEY ("agendaItemId") REFERENCES "RawAgendaItemConsiderations" ("agendaItemId") ON DELETE CASCADE ON UPDATE CASCADE
+	);
+
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+	DROP TABLE IF EXISTS "AgendaItemSubjectTerms";
+  `.execute(db);
+}

--- a/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
+++ b/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
@@ -3,15 +3,13 @@ import { sql, type Kysely } from 'kysely';
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     CREATE TABLE "AgendaItemSubjectTerms" (
-      "reference" TEXT NOT NULL,
-      "meetingId" INTEGER NOT NULL,
       "agendaItemId" INTEGER NOT NULL,
       "subjectTermRaw" TEXT NOT NULL,
       "subjectTermNormalized" TEXT NOT NULL,
-      "subjectTermSlug" TEXT NOT NULL,
-      PRIMARY KEY ("agendaItemId", "subjectTermSlug"),
-      CONSTRAINT fk_agenda_item FOREIGN KEY ("reference", "meetingId") REFERENCES "RawAgendaItemConsiderations" ("reference", "meetingId") ON DELETE CASCADE ON UPDATE CASCADE
+      "subjectTermSlug" TEXT NOT NULL
     );
+
+    CREATE UNIQUE INDEX "idx_agenda_item_subject_terms" ON "AgendaItemSubjectTerms" ("agendaItemId", "subjectTermSlug");
   `.execute(db);
 }
 

--- a/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
+++ b/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
@@ -2,20 +2,20 @@ import { sql, type Kysely } from 'kysely';
 
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
-	CREATE TABLE "AgendaItemSubjectTerms" (
-	"agendaItemId" INTEGER NOT NULL,
-	"subjectTermRaw" TEXT NOT NULL,
-	"subjectTermNormalized" TEXT NOT NULL,
-	"subjectTermSlug" TEXT NOT NULL,
-	PRIMARY KEY ("agendaItemId", "subjectTermSlug"));
-	FOREIGN KEY ("agendaItemId") REFERENCES "RawAgendaItemConsiderations" ("agendaItemId") ON DELETE CASCADE ON UPDATE CASCADE
-	);
-
+    CREATE TABLE "AgendaItemSubjectTerms" (
+      "id" UUID NOT NULL,
+      "agendaItemId" INTEGER NOT NULL,
+      "subjectTermRaw" TEXT NOT NULL,
+      "subjectTermNormalized" TEXT NOT NULL,
+      "subjectTermSlug" TEXT NOT NULL,
+      PRIMARY KEY ("agendaItemId", "subjectTermSlug"),
+      CONSTRAINT fk_agenda_item FOREIGN KEY ("id") REFERENCES "RawAgendaItemConsiderations" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    );
   `.execute(db);
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
   await sql`
-	DROP TABLE IF EXISTS "AgendaItemSubjectTerms";
+    DROP TABLE IF EXISTS "AgendaItemSubjectTerms";
   `.execute(db);
 }

--- a/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
+++ b/src/migrations/1748735120046_AddAgendaItemSubjectTermsTable.ts
@@ -3,13 +3,14 @@ import { sql, type Kysely } from 'kysely';
 export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     CREATE TABLE "AgendaItemSubjectTerms" (
-      "id" UUID NOT NULL,
+      "reference" TEXT NOT NULL,
+      "meetingId" INTEGER NOT NULL,
       "agendaItemId" INTEGER NOT NULL,
       "subjectTermRaw" TEXT NOT NULL,
       "subjectTermNormalized" TEXT NOT NULL,
       "subjectTermSlug" TEXT NOT NULL,
       PRIMARY KEY ("agendaItemId", "subjectTermSlug"),
-      CONSTRAINT fk_agenda_item FOREIGN KEY ("id") REFERENCES "RawAgendaItemConsiderations" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+      CONSTRAINT fk_agenda_item FOREIGN KEY ("reference", "meetingId") REFERENCES "RawAgendaItemConsiderations" ("reference", "meetingId") ON DELETE CASCADE ON UPDATE CASCADE
     );
   `.execute(db);
 }

--- a/src/scripts/processAgendaItemSubjectTerms.ts
+++ b/src/scripts/processAgendaItemSubjectTerms.ts
@@ -1,0 +1,8 @@
+import { processAgendaItemSubjectTerms } from '@/database/queries/agendaItems';
+import { createDB } from '@/database/kyselyDb';
+
+// For the purpose of updating the subject terms in the database,
+await processAgendaItemSubjectTerms(createDB());
+
+// so manually exit here, for consistency w/ other scripts
+process.exit(0);

--- a/src/scripts/processAgendaItemSubjectTerms.ts
+++ b/src/scripts/processAgendaItemSubjectTerms.ts
@@ -1,7 +1,7 @@
 import { processAgendaItemSubjectTerms } from '@/database/queries/agendaItems';
 import { createDB } from '@/database/kyselyDb';
 
-// For the purpose of updating the subject terms in the database,
+// For the purpose of updating the subject terms in the database as a separate job
 await processAgendaItemSubjectTerms(createDB());
 
 // so manually exit here, for consistency w/ other scripts


### PR DESCRIPTION
## Description
This PR proposes a separate indexed table that structures agenda item subject terms (tags) into separate rows and slugifies them, allowing efficient join on _TagCategories.tags_ and _AgendaItemSubjectTerms.subjectTermSlug_ to assign a category to Agenda Items with the following:

- Added functions to normalize and explode subjectTerms from ingested agendaItems and stored agenda items in table RawAgendaItemConsiderations
- Create an _AgendaItemSubjectTerms_ table and index on _columns =  ["agendaItemId", "subjectTermSlug"]_
    - _"subjectTermRaw"_ shows special characters like e.g. "&" while _"subjectTermNormalized"_ replaced them with e.g. "and"
- Added _src/processAgendaItemSubjectTerms.ts_ to apply to stored data (temporary solution)

## Related issue
#127 

## Review Checklist:
- [ ] Appropriate table definition
- [ ] Subject term processing functions work as intended
