### PR TITLE
Fix alignment + spacing issues in cards

### DIFF
--- a/src/app/labs/page.tsx
+++ b/src/app/labs/page.tsx
@@ -35,7 +35,7 @@ const LabCard = ({
   const Content = (
     <Card>
       <CardHeader>
-        <h2>{title}</h2>
+        <h2 className="mb-0">{title}</h2>
       </CardHeader>
       <CardContent className="relative h-48">
         <Image src={imageSrc} alt={imageAlt} layout="fill" objectFit="cover" />

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -24,7 +24,7 @@ const CardHeader = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'flex flex-row p-3 sm:py-3 sm:px-8 items-start content-start justify-between h-max rounded-t-[13px] border-neutral-100 dark:border-neutral-600 border-b',
+      'flex flex-row p-4 md:px-6 items-start content-start justify-between h-max rounded-t-[13px] border-neutral-100 dark:border-neutral-600 border-b',
       className,
     )}
     {...props}
@@ -38,10 +38,7 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn(
-      'text-md font-semibold leading-none tracking-tight',
-      className,
-    )}
+    className={cn('text-md font-semibold mb-3', className)}
     {...props}
   />
 ));
@@ -51,7 +48,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn('p-6', className)} {...props} />
+  <div ref={ref} className={cn('p-4 md:p-6', className)} {...props} />
 ));
 CardContent.displayName = 'CardContent';
 
@@ -62,7 +59,7 @@ const CardFooter = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'flex items-center justify-stretch py-4 px-3 gap-x-3 sm:justify-end sm:gap-x-2 sm:p-6 border-t border-neutral-100 dark:border-neutral-600 rounded-b-[13px]',
+      'flex items-center p-4 md:px-6 gap-x-2 sm:gap-x-3 justify-stretch sm:justify-end border-t border-neutral-100 dark:border-neutral-600 rounded-b-[13px]',
       className,
     )}
     {...props}


### PR DESCRIPTION
This PR fixes various alignment and spacing issues in the Card component, which is currently used to display actions on the Actions page, and our experiments on the Labs page.

**Actions**

* Aligns the contents of the card header/body/footer on either side of the card.
* Adds leading (space between lines) in the action title in the card body -- more spacing here helps in readability.

Desktop:

| Before | After | 
|-|-|
| <img width="1034" height="615" alt="474179115-7ef96058-d153-4fd8-b25d-1a59d7a729ee" src="https://github.com/user-attachments/assets/c82bcd9a-8404-4c77-b3c8-87b6a7a9196b" />| <img width="1016" height="608" alt="image" src="https://github.com/user-attachments/assets/2ec1aec6-7c5d-452d-8350-2c4ff233bc4a" /> |

Mobile:

| Before | After | 
|-|-|
|<img width="620" height="921" alt="image" src="https://github.com/user-attachments/assets/b35b0cfe-b752-401f-b416-b415928249d3" />|<img width="630" height="935" alt="image" src="https://github.com/user-attachments/assets/1eb60a36-b5f4-427c-ac02-517b31316b4e" />|

**Labs**

* Vertically centers card title in the title area

Desktop:

| Before | After | 
|-|-|
| <img width="1175" height="777" alt="image" src="https://github.com/user-attachments/assets/ca81550f-e225-432a-bff2-3e7d9d880f33" />| <img width="1176" height="759" alt="image" src="https://github.com/user-attachments/assets/724db956-48f7-4205-b694-b6a093b1f501" />|

Mobile:

| Before | After | 
|-|-|
|<img width="618" height="918" alt="image" src="https://github.com/user-attachments/assets/22156f50-712f-472e-b143-7fc78a9e6633" />|<img width="621" height="920" alt="image" src="https://github.com/user-attachments/assets/a0a953dc-8959-4e7d-acf8-59a1e26e5335" />|
