### PR TITLE
Added background resource links to full agenda item card

### DIFF
--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -12,7 +12,7 @@ import {
 import type { AgendaItem } from '@/database/queries/agendaItems';
 import { useSearch } from '@/contexts/SearchContext';
 import { Chip, ChipLink } from '@/components/ui/chip';
-import { Link2, MessageSquarePlus, Speech } from 'lucide-react';
+import { Link2, MessageSquarePlus, Paperclip, Speech } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -165,16 +165,17 @@ export function FullPageAgendaItemCard({
       )}
       {item.backgroundAttachmentId && (
         <>
-          <h4 className="mt-8 font-bold">Background Information</h4>
+          <h4 className="mt-8 mb-1 font-bold">Background Information</h4>
           {item.backgroundAttachmentId.map((id, i) => {
             return (
               <ChipLink
+                className="pl-2 mr-1"
                 href={`https://www.toronto.ca/legdocs/mmis/${item.termYear}/${item.agendaCd.toLowerCase()}/bgrd/backgroundfile-${id}.pdf`}
                 key={i}
                 target="_blank"
                 variant="outline"
               >
-                <Link2 size={14} />
+                <Paperclip size={14} />
                 Attachment {i + 1}
               </ChipLink>
             );


### PR DESCRIPTION
Solution for [project item #17](https://github.com/orgs/civic-dashboard/projects/3?pane=issue&itemId=94474274&issue=civic-dashboard%7Ccivic-dashboard-web%7C17) which evolved into the request of [issue #150](https://github.com/civic-dashboard/civic-dashboard-web/issues/150) to show links to background attachment files for individual action items. 

If background attachments are found for the agenda item they will be shown at the bottom of the agenda item card. This solution will make a separate link for each background attachment ID, generating the URL with the pattern specified by @jeromegv [here](https://github.com/civic-dashboard/civic-dashboard-web/issues/150#issuecomment-2914456636).

**Other considerations**

Currently, links on each item are titled Resource 1, Resource 2, etc. It may be desired that we show some information of the link, such as the title of the document; as far as I know this information is not currently in the database and does not seem available without additional HTTP requests. This is important as some items have resources that are confidential, like [here](https://secure.toronto.ca/council/agenda-item.do?item=2025.RZ10.2), but the item links are still provided in the data and will redirect to a Requested Document Not Available page. 

Moving forward with this task, is there other data we want to display on the item page?
