### PR TITLE
Fix typo with incorrect agenda item ID in subject line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Citizen Dashboard
+Copyright (c) 2025 Citizen Dashboard
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/components/deputation-modals/RequestToSpeakModal.tsx
+++ b/src/components/deputation-modals/RequestToSpeakModal.tsx
@@ -57,7 +57,7 @@ export function RequestToSpeakModal({
       year: 'numeric',
     },
   );
-  const subject = `Request to appear before ${formattedDate} ${decisionBody.decisionBodyName} on item ${agendaItem.agendaItemId}`;
+  const subject = `Request to appear before ${formattedDate} ${decisionBody.decisionBodyName} on item ${agendaItem.reference}`;
   const bodyStartParagraphs = [
     'To the City Clerk:',
     `I would like to appear before the ${formattedDate} ${decisionBody.decisionBodyId} to speak on item ${agendaItem.reference}, ${agendaItem.agendaItemTitle}.`,


### PR DESCRIPTION
# Context
- Fixes #239 
- Subject line when submitting a comment is correct, so only the request to comment feature needs a fix