### PR TITLE
#257 update compatibility date of wrangler to fix issue with councillor page

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 main = ".open-next/worker.js"
 name = "civic-dashboard-web"
-compatibility_date = "2024-09-23"
+compatibility_date = "2025-05-05"
 compatibility_flags = ["nodejs_compat"]
 assets = { directory = ".open-next/assets", binding = "ASSETS" }
 routes = [{ pattern = "civicdashboard.ca", custom_domain = true }]


### PR DESCRIPTION
update compatibility date of wrangler to a date that supports FinalizationRegistry

The new date `2025-05-05` was chosen based on this:
https://developers.cloudflare.com/workers/configuration/compatibility-flags/#flags-history

To fix issue #257 and partially #238 which prevented access to councillor pages
(#238 will still require to reduce the size of the database queries, but this allows to at least load the councillor page in some cases, not "never")

This bug likely started with this PR:
https://github.com/civic-dashboard/civic-dashboard-web/pull/232

Where I updated wrangler and @opennextjs/cloudflare, and within those new package versions, something started to depend on the FinalizationRegistry... and this thing was not supported by our compatibility date

What a mess