### PR TITLE
Remove Ward 25 By-Election FAQ from the footer #269

### DIFF
--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -32,14 +32,6 @@ export default function Footer() {
                   Labs
                 </Link>
               </li>
-              <li>
-                <Link
-                  href="/ward25faq"
-                  className="hover:text-blue-400 transition-colors duration-200 block"
-                >
-                  Ward 25 By-Election FAQ
-                </Link>
-              </li>
             </ul>
           </div>
 


### PR DESCRIPTION
Will still be accessible through https://civicdashboard.ca/ward25faq directly
Fixes #269 