### PR TITLE
Changing COMING SOON for the actual wiki page URL on "How council work" page

### DIFF
--- a/src/app/how-council-works/page.tsx
+++ b/src/app/how-council-works/page.tsx
@@ -43,9 +43,9 @@ const ProcessImage = ({ src, alt }: { src: string; alt?: string }) => (
 const WikiLink = () => (
   <span className="italic">
     For a more in-depth explanation, visit the{' '}
-    <a href="/wiki" className="classic-link">
+    <Link href="/wiki" className="classic-link">
       Civic Dashboard Wiki
-    </a>
+    </Link>
     .
   </span>
 );


### PR DESCRIPTION
## Description

Resolves #286 

Changing COMING SOON link for the actual wiki page URL on how council work page

Also it says to check out the wiki to know how to get more involved, and we have no such content at the moment, so removing


## Testing instructions

Go to the `How Council Works` page and ensure that where it mentions the wiki that it actually links to the wiki, not the coming soon page.