### PR TITLE
Use human-readable name of committee instead of ID in email

### DIFF
--- a/src/components/deputation-modals/RequestToSpeakModal.tsx
+++ b/src/components/deputation-modals/RequestToSpeakModal.tsx
@@ -60,7 +60,7 @@ export function RequestToSpeakModal({
   const subject = `Request to appear before ${formattedDate} ${decisionBody.decisionBodyName} on item ${agendaItem.reference}`;
   const bodyStartParagraphs = [
     'To the City Clerk:',
-    `I would like to appear before the ${formattedDate} ${decisionBody.decisionBodyId} to speak on item ${agendaItem.reference}, ${agendaItem.agendaItemTitle}.`,
+    `I would like to appear before the ${formattedDate} ${decisionBody.decisionBodyName} to speak on item ${agendaItem.reference}, ${agendaItem.agendaItemTitle}.`,
   ];
   const getFullBodyText = () => {
     const fields = [`${nameLabel} ${name}`];

--- a/src/components/deputation-modals/SubmitCommentModal.tsx
+++ b/src/components/deputation-modals/SubmitCommentModal.tsx
@@ -49,7 +49,7 @@ export function SubmitCommentModal({
   const subject = `My comments for ${agendaItem.reference} on ${formattedDate} ${decisionBody.decisionBodyName}`;
   const bodyStartParagraphs = [
     'To the City Clerk:',
-    `Please add my comments to the agenda for the ${formattedDate} ${decisionBody.decisionBodyId} meeting on item ${agendaItem.reference}, ${agendaItem.agendaItemTitle}`,
+    `Please add my comments to the agenda for the ${formattedDate} ${decisionBody.decisionBodyName} meeting on item ${agendaItem.reference}, ${agendaItem.agendaItemTitle}`,
     'I understand that my comments and the personal information in this email will form part of the public record and that my name will be listed as a correspondent on agendas and minutes of City Council or its committees. Also, I understand that agendas and minutes are posted online and my name may be indexed by search engines like Google.',
   ];
   const commentsHeading = 'Comments:';


### PR DESCRIPTION
## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
The email body for submitting comments and requests to speak uses the committee ID instead of the human-readable committee name.

<!-- 2. Give a high-level description of what this PR does. -->
<!-- What was the behaviour before? What should it be now? -->

### Before
<img width="906" height="818" alt="Screenshot 2025-12-01 150915" src="https://github.com/user-attachments/assets/e26a4665-9e5b-44d5-98e9-02a1370bcbba" />

<img width="912" height="960" alt="Screenshot 2025-12-01 151012" src="https://github.com/user-attachments/assets/d2682d39-a2d9-44f0-9a58-a303a54aa86a" />


### After

<img width="922" height="842" alt="Screenshot 2025-12-01 152058" src="https://github.com/user-attachments/assets/eba9a393-f332-485b-9faa-7e66ad7d1fea" />

<img width="914" height="962" alt="Screenshot 2025-12-01 152122" src="https://github.com/user-attachments/assets/f83154b5-0ef2-4094-aa25-1a69d4468276" />


<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->

Click on any current agenda item and click on "Submit a comment" or "Request to speak".

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] I have performed a self-review of my code
- [x] I have tested these changes in the preview deployment
