### PR TITLE
feat: add civicdashboard.ca/analytics redirect

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -10,6 +10,16 @@ const nextConfig = {
     ],
     domains: ['contrib.wp.intra.prod-toronto.ca'],
   },
+  async redirects() {
+    return [
+      {
+        source: '/analytics',
+        destination:
+          'https://cloud.umami.is/analytics/eu/share/6R9CNotgCUNEmDL5/civicdashboard.ca',
+        permanent: false,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -65,12 +65,12 @@ export default function Footer() {
                   </Link>
                 </li>
                 <li>
-                  <ExternalLink
-                    href="https://eu.umami.is/share/6R9CNotgCUNEmDL5/civicdashboard.ca?host=civicdashboard.ca"
+                  <Link
+                    href="/analytics"
                     className="hover:text-blue-400 transition-colors duration-200"
                   >
                     Analytics
-                  </ExternalLink>
+                  </Link>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
## Description
Adds an ez redirect to our analytics dashboard.

## Testing instructions

Navigating to `/analytics` via either the browser's address bar or clicking the link in the footer should go to our Umami dashboard.

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in the preview deployment
- [x] I have made corresponding changes to the documentation (if relevant)
