### PR TITLE
Added validation to Actions page Get Email Alerts button to prevent empty values

### DIFF
--- a/src/components/subscribeToSearchButton.tsx
+++ b/src/components/subscribeToSearchButton.tsx
@@ -67,6 +67,7 @@ export const SubscribeToSearchButton = () => {
               ref={emailInputRef}
               type="email"
               placeholder="Enter email..."
+              required
               onChange={onChange}
             />
             {sendState === 'loading' ? (


### PR DESCRIPTION
## Description

Resolves #210 

Adds validation to prevent empty value being submitted in the "Get Email Alerts" email field on the Actions page.

**BEFORE**
Entering a blank value in the email field would trigger an infinite spinner and drop a 500 (Internal Server Error) in the dev console.
<img width="1448" height="702" alt="Screenshot 2026-01-21 at 1 34 18 PM" src="https://github.com/user-attachments/assets/fcb2fc47-6747-43e2-ae83-3f2f66b6d3bf" />

**AFTER**
Form now no longer accepts the empty value and asks the user to fill out the field:
<img width="1448" height="702" alt="Screenshot 2026-01-21 at 1 28 34 PM" src="https://github.com/user-attachments/assets/16032eba-f8aa-4597-b420-0265c174fd47" />

## Testing instructions

Navigate to /Actions by clicking the nav bar. Click on the "Get Email Alerts" button and attempt to enter an empty value in the Email field. 

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
