### PR TITLE
fix(wiki): fix back-to-top button disappearing near footer

### DIFF
--- a/src/app/wiki/wikiDocClient.tsx
+++ b/src/app/wiki/wikiDocClient.tsx
@@ -142,38 +142,13 @@ export default function WikiDocClient({ filename }: { filename: string }) {
     })();
   }, [filename]);
 
-  // Show/hide scroll to top button and stop at footer
+  // Show scroll to top button on entire page
   useEffect(() => {
     const handleScroll = () => {
       const scrollY = window.scrollY;
 
       // Show button when scrolled down 400px
-      const shouldShow = scrollY > 400;
-
-      // Find footer element
-      const footer = document.querySelector('footer');
-      if (!footer) {
-        setShowScrollTop(shouldShow);
-        setButtonBottom('2rem');
-        return;
-      }
-
-      const footerRect = footer.getBoundingClientRect();
-      const viewportHeight = window.innerHeight;
-      const buttonHeight = 56; // approximate button height + padding
-      const defaultBottom = 32; // 2rem = 32px
-      const buttonBottomEdge = viewportHeight - defaultBottom;
-
-      // Check if button would overlap footer
-      const wouldOverlapFooter =
-        footerRect.top < buttonBottomEdge + buttonHeight;
-
-      if (wouldOverlapFooter) {
-        // Hide button when it reaches footer
-        setShowScrollTop(false);
-      } else {
-        setShowScrollTop(shouldShow);
-      }
+      setShowScrollTop(scrollY > 400);
 
       // Keep button at default position
       setButtonBottom('2rem');


### PR DESCRIPTION
## Description
Fixes the issue where the "Back to top" button on Wiki pages would disappear when approaching the footer. The button is now pinned to the bottom-right corner and remains visible

Closes #329 - https://github.com/civic-dashboard/civic-dashboard-web/issues/329

## Changes

- Simplified scroll handler in [wikiDocClient.tsx] to remove dynamic footer-avoidance logic.
- Guaranteed a fixed position for the button at the bottom of the page.

## Verification
Confirmed that the button stays visible and stable on:
- `/wiki/Deputations.html`
- `/wiki/GovernmentGuide.html`