### PR TITLE
feat: add links to ward and councillor overview from councillor's pages

### DIFF
--- a/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
+++ b/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
@@ -47,12 +47,12 @@ export default function CouncillorBio({
         <div>
           <h1 className="text-3xl font-bold mb-2">{councillor.contactName}</h1>
           <p className="text-gray-600 dark:text-gray-300 mb-4">
-            <ExternalLink href={councillorProfileURL} className='classic-link'>
+            <ExternalLink href={councillorProfileURL} className="classic-link">
               Councillor Profile
             </ExternalLink>
           </p>
           <p className="text-gray-600 dark:text-gray-300 mb-4">
-            <ExternalLink href={wardURL} className='classic-link'>
+            <ExternalLink href={wardURL} className="classic-link">
               Ward {councillor.wardId}, {councillor.wardName}
             </ExternalLink>
           </p>


### PR DESCRIPTION
## Description

Resolves #302 

<!-- 2. Give a high-level description of what this PR does. -->

Before:
There was no link to the councillor's profile, and the councillor's ward didn't link to the ward page on the City of Toronto website.
<img width="1448" height="702" alt="302-before" src="https://github.com/user-attachments/assets/171e3fa6-b1be-4a8e-9339-71194ccfcb09" />

After:
A link to the councillor's profile has been added, and the councillor's ward now does link to the ward page on the City of Toronto website.
<img width="1448" height="702" alt="302-after" src="https://github.com/user-attachments/assets/84ef879a-3850-4c84-beff-07037145230c" />

## Testing instructions

Navigate to /Councillors by clicking on the nav bar. Click on one of the councillors. 

Click on the "Councillor Profile" text underneath the councillor's name. Wait for the page on the City of Toronto website to load to verify the link leads to the correct page.

Return to the councillor's page. Click on the councillor's ward. Wait for the page on the City of Toronto website to load to verify the link leads to the correct page.

## Important

An issue related to this change which may need to be resolved before merge is that the ward name for Ward 24 in the database is Scarborough East. But this ward is actually called Scarborough-Guildwood. This discrepancy means the ward link for Paul Ainslie, the councillor for Ward 24, leads to a page not found. 

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
