### PR TITLE
Fix issue 329 - Update Back To Top button on Wiki Pages

### DIFF
--- a/src/app/wiki/wikiDocClient.tsx
+++ b/src/app/wiki/wikiDocClient.tsx
@@ -148,32 +148,7 @@ export default function WikiDocClient({ filename }: { filename: string }) {
       const scrollY = window.scrollY;
 
       // Show button when scrolled down 400px
-      const shouldShow = scrollY > 400;
-
-      // Find footer element
-      const footer = document.querySelector('footer');
-      if (!footer) {
-        setShowScrollTop(shouldShow);
-        setButtonBottom('2rem');
-        return;
-      }
-
-      const footerRect = footer.getBoundingClientRect();
-      const viewportHeight = window.innerHeight;
-      const buttonHeight = 56; // approximate button height + padding
-      const defaultBottom = 32; // 2rem = 32px
-      const buttonBottomEdge = viewportHeight - defaultBottom;
-
-      // Check if button would overlap footer
-      const wouldOverlapFooter =
-        footerRect.top < buttonBottomEdge + buttonHeight;
-
-      if (wouldOverlapFooter) {
-        // Hide button when it reaches footer
-        setShowScrollTop(false);
-      } else {
-        setShowScrollTop(shouldShow);
-      }
+      setShowScrollTop(scrollY > 400);
 
       // Keep button at default position
       setButtonBottom('2rem');


### PR DESCRIPTION
## Description
Fixes the issue where the "Back to top" button on Wiki pages would disappear when approaching the footer. The button is now pinned to the bottom-right corner 

Closes #329

## Changes
- Simplified scroll handler in [wikiDocClient.tsx](cci:7://file:///home/hejustino_hjdconsulting_ca/repos/personal/civic-dashboard-web/src/app/wiki/wikiDocClient.tsx:0:0-0:0) to remove dynamic footer-avoidance logic.
- Guaranteed a fixed position for the button at the bottom of the page.

## Verification
Confirmed that the button stays visible and stable on:
- `/wiki/Deputations.html`
- `/wiki/GovernmentGuide.html`