### PR TITLE
Fix empty email database bug which creates duplicate emails being sent

### DIFF
--- a/src/backend/emails/subscriptions.ts
+++ b/src/backend/emails/subscriptions.ts
@@ -16,6 +16,7 @@ export async function subscribeToSearch({
   email,
   filters: { textQuery, tags, decisionBodyIds },
 }: SubscribeToSearchArgs) {
+  if (!email || !email.trim()) return;
   const filters = {
     textQuery,
     tags,

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -392,6 +392,7 @@ export const getSubscribersToNotify = async (db: Kysely<DB>) => {
               ),
             ]),
           )
+          .where('Subscribers.email', '!=', '')
           .as('matchingSubscriptions'),
       (join) => join.onTrue(),
     )

--- a/src/database/queries/subscriptions.ts
+++ b/src/database/queries/subscriptions.ts
@@ -93,6 +93,7 @@ export const validateToken = async (db: Kysely<DB>, token: string) => {
 };
 
 export const getOrCreateSubscriber = async (db: Kysely<DB>, email: string) => {
+  if (!email || !email.trim()) throw new Error('Email cannot be empty');
   return await db
     .with('new', (db) =>
       db


### PR DESCRIPTION
## Description

Fix empty email database bug which creates duplicate emails being sent

1. prevent empty email from being submitted
2. if there is an empty email row in the DB, we don't query it

Resolves #249 
Resolves #338 

## Testing instructions

We could never reproduce the bug as how those empty emails were being added to the database
But at the minimum for testing we need to test signing up to the email notification and confirm we are being added to the database and receive the email notifications

## Checklist


- [ X] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [X ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
