### PR TITLE
Add youth tag for agenda search and subscriptions

### DIFF
--- a/src/constants/tags.ts
+++ b/src/constants/tags.ts
@@ -95,7 +95,7 @@ export const allTags = {
   },
   youth: {
     displayName: 'youth',
-    searchQuery: 'youth OR "kids" OR "teenagers" OR "child"',
+    searchQuery: 'youth OR kids OR teenagers',
   },
 } as const satisfies Record<string, Tag>;
 


### PR DESCRIPTION
## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
ISSUE: No prior issue; mentioned in last CivicTechTO meetup that one of our potential marketing partners wanted a "youth" tag added

<!-- 2. Give a high-level description of what this PR does. -->
<!-- What was the behaviour before? What should it be now? -->
BEFORE: No youth tag to search by Agenda Items
AFTER: Youth tag to search by in Agenda Items

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->

<img width="1113" height="760" alt="image" src="https://github.com/user-attachments/assets/9dd01989-07ee-4be1-98c1-7bf655f7ad6d" />
<img width="1323" height="792" alt="image" src="https://github.com/user-attachments/assets/ced3dc68-04c1-4ba5-b756-e62f8ff9fbc9" />

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->
1. Allows user to search by youth in the agenda items section. On desktop + mobile.

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in the preview deployment
- [x] I have made corresponding changes to the documentation (if relevant)
