### PR TITLE
Add the missing TTC committee (decision body) to our constants file

### DIFF
--- a/src/constants/decisionBodies.ts
+++ b/src/constants/decisionBodies.ts
@@ -14346,4 +14346,79 @@ export const decisionBodies: Record<number, DecisionBody> = {
       },
     ],
   },
+  2984: {
+    decisionBodyId: 2984,
+    committeeCodeId: 1401,
+    termId: 8,
+    decisionBodyName:
+      'Toronto Transit Commission - Strategic Planning Committee',
+    email: 'commissionservices@ttc.ca',
+    duties:
+      'The Strategic Planning Committee assists the TTC Board to guide long-term planning focused on service, fare, safety and customer experience initiatives in support of customer growth. The Strategic Planning Committee also provides advice and insights on emerging priorities, scenarios and critical issues for the TTC’s annual budget process, including evaluating new opportunities, assessing risks, and ensuring alignment between financial resources and opportunities to grow ridership in the immediate and long-term.',
+    dbdyStatusCd: 'ACTIVE',
+    phoneAreaCode: '416',
+    phoneNumber: '3933744',
+    webpostInd: 'Y',
+    contactFirstName: 'Chrisanne',
+    contactLastName: 'Finnerty',
+    generalAddress:
+      'Toronto Transit Commission – McBrien Building<br>\r\n1900 Yonge Street<br>\r\nToronto, ON M5H 2N2',
+    decisionBodyPublishLabelCd: 'CMMSSION',
+    committeeCode: { committeeCodeId: 1401, committeeCode: 'TTS' },
+    decisionBodyType: { tier: 3 },
+    term: {
+      termId: 8,
+      termType: '2022-2026',
+      trmStartDate: 1668488400000,
+      trmEndDate: 1794632400000,
+    },
+    members: [
+      {
+        apptEndDate: 1794632400000,
+        firstName: 'Alejandra',
+        lastName: 'Bravo',
+        salutationCd: 'Chair',
+        memberUrl:
+          'https://www.toronto.ca/city-government/council/members-of-council/councillor-ward-9/',
+        apptStartDate: 1744776000000,
+        memberId: 81,
+      },
+      {
+        apptEndDate: 1794632400000,
+        firstName: 'Fenton',
+        lastName: 'Jagdeo',
+        salutationCd: 'Citizen',
+        apptStartDate: 1744776000000,
+        memberId: 4721,
+      },
+      {
+        apptEndDate: 1794632400000,
+        firstName: 'Joe',
+        lastName: 'Mihevc',
+        salutationCd: 'Citizen',
+        apptStartDate: 1744776000000,
+        memberId: 4821,
+      },
+      {
+        apptEndDate: 1794632400000,
+        firstName: 'Jamaal',
+        lastName: 'Myers',
+        salutationCd: 'Councillor',
+        memberUrl:
+          'https://www.toronto.ca/city-government/council/members-of-council/councillor-ward-23/',
+        apptStartDate: 1744776000000,
+        memberId: 3826,
+      },
+      {
+        apptEndDate: 1794632400000,
+        firstName: 'Dianne',
+        lastName: 'Saxe',
+        salutationCd: 'Councillor',
+        memberUrl:
+          'https://www.toronto.ca/city-government/council/members-of-council/councillor-ward-11/',
+        apptStartDate: 1744776000000,
+        memberId: 3821,
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## Description

1. 
Resolves #353

2. 

While reviewing our data sources, I noticed the `Toronto Transit Commission - Strategic Planning Committee` is missing from our list of decision bodies (committees). This is what powers our list of decision body we can filter by on the actions page

We do not auto-update this list of decision bodies as part of our data pipeline with TMMIS, it is manual right now, so i have to manually update it.

3. 

<img width="527" height="413" alt="Screenshot 2026-03-04 at 12 36 40 PM" src="https://github.com/user-attachments/assets/58056081-877d-423b-bae1-a7039ba9df31" />

## Testing instructions

On the preview link, confirm that the new committee is within the list of decision body we can filter by on the Actions page

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [X ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
