### PR TITLE
add meta description to the generic wiki page

### DIFF
--- a/src/app/wiki/page.tsx
+++ b/src/app/wiki/page.tsx
@@ -3,6 +3,8 @@ import WikiIndexClient from '@/app/wiki/wikiIndexClient';
 
 export const metadata: Metadata = {
   title: 'Wiki – Civic Dashboard',
+  description:
+    'Explore Civic Dashboard’s wiki for clear, accessible guides on Toronto City Council, municipal powers, elections, councillors, and how local government works',
 };
 
 export default function WikiIndex() {


### PR DESCRIPTION
## Description

Resolves #307 

Adds a meta description to https://civicdashboard.ca/wiki


## Testing instructions

Go to the /wiki page on the preview link, open the dev tools and check out the html source of the page, confirm the meta description says `Explore Civic Dashboard’s wiki for clear, accessible guides on Toronto City Council, municipal powers, elections, councillors, and how local government works`

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [ ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
