### PR TITLE
Open Graph description using the first paragraph of agendaItemSummary on the agenda item page

### DIFF
--- a/src/app/actions/item/[reference]/page.tsx
+++ b/src/app/actions/item/[reference]/page.tsx
@@ -4,6 +4,7 @@ import { FullPageAgendaItemCard } from '@/components/AgendaItemCard';
 import { decisionBodies } from '@/constants/decisionBodies';
 import { createDB } from '@/database/kyselyDb';
 import { getAgendaItemByReference } from '@/database/queries/agendaItems';
+import { stripHtmlAndGetFirstParagraph } from '@/logic/sanitize';
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const db = createDB();
@@ -14,8 +15,25 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
     return {};
   }
 
+  const fullDescription = stripHtmlAndGetFirstParagraph(
+    agendaItem.agendaItemSummary,
+  );
+  const description =
+    fullDescription.length > 200
+      ? fullDescription
+          .slice(0, 197)
+          .trim()
+          .replace(/\s+\S+$/, '') + '...'
+      : fullDescription;
+
   return {
     title: `${agendaItem.reference} - ${agendaItem.agendaItemTitle} – Civic Dashboard`,
+    ...(description && {
+      description,
+      openGraph: {
+        description,
+      },
+    }),
   };
 }
 

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -25,6 +25,48 @@ export const sanitize = (text: string) => {
   return safeSummary;
 };
 
+export const stripHtmlAndGetFirstParagraph = (html: string) => {
+  if (!html) return '';
+
+  const entities: Record<string, string> = {
+    '&nbsp;': ' ',
+    '&rsquo;': "'",
+    '&#39;': "'",
+    '&apos;': "'",
+    '&ldquo;': '"',
+    '&rdquo;': '"',
+    '&quot;': '"',
+    '&lsquo;': "'",
+    '&hellip;': '...',
+    '&ndash;': '-',
+    '&mdash;': '—',
+    '&middot;': '·',
+    '&bull;': '•',
+    '&#8209;': '-',
+    '&#8239;': ' ',
+    '&trade;': '™',
+    '&lt;': '<',
+    '&gt;': '>',
+    '&amp;': '&',
+  };
+
+  // 1. Replace block elements and line breaks with a newline to identify boundaries.
+  // 2. Strip all remaining HTML tags.
+  // 3. Decode common HTML entities.
+  const text = html
+    .replace(/<\/?(p|br|div|li|tr|td|h[1-6])[^>]*>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&[a-z0-9#]+;/gi, (m) => entities[m.toLowerCase()] || m);
+
+  // 4. Split by newline and take the first non-empty line.
+  return (
+    text
+      .split('\n')
+      .map((line) => line.trim().replace(/\s+/g, ' '))
+      .find((line) => line.length > 0) || ''
+  );
+};
+
 export const validateUrl = async (url: string | null | undefined) => {
   if (!url) return false;
   try {


### PR DESCRIPTION
## Description

Resolves #287 

Set the Open Grah and Meta Description of agenda item page using the first paragraph of agendaItemSummary


## Testing instructions

Go to Actions, select an agenda item, go to the page that shows the full agenda item, confirm in the source code that the meta description and open graph description is set.

## Checklist

- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
