### PR TITLE
Fix bug with the previous PR to adjust time to move items to "Past Items"

### DIFF
--- a/src/backend/emails/subscriptions.ts
+++ b/src/backend/emails/subscriptions.ts
@@ -8,6 +8,8 @@ import { searchAgendaItems } from '@/database/queries/agendaItems';
 import { allTags } from '@/constants/tags';
 import { decisionBodies } from '@/constants/decisionBodies';
 
+import { getStartOfToday } from '@/logic/date';
+
 type SubscribeToSearchArgs = {
   email: string;
   filters: SubscribableSearchFilters;
@@ -27,8 +29,7 @@ export async function subscribeToSearch({
     email,
     ...filters,
   });
-  const startOfToday = new Date();
-  startOfToday.setHours(0, 0, 0, 0);
+  const startOfToday = getStartOfToday();
 
   const currentResults = await searchAgendaItems(db, {
     options: {

--- a/src/backend/emails/subscriptions.ts
+++ b/src/backend/emails/subscriptions.ts
@@ -30,7 +30,11 @@ export async function subscribeToSearch({
   const currentResults = await searchAgendaItems(db, {
     options: {
       ...filters,
-      minimumDate: new Date(),
+      minimumDate: (() => {
+        const d = new Date();
+        d.setHours(0, 0, 0, 0);
+        return d;
+      })(),
       sortBy: 'relevance',
       sortDirection: 'descending',
     },

--- a/src/backend/emails/subscriptions.ts
+++ b/src/backend/emails/subscriptions.ts
@@ -27,14 +27,13 @@ export async function subscribeToSearch({
     email,
     ...filters,
   });
+  const startOfToday = new Date();
+  startOfToday.setHours(0, 0, 0, 0);
+
   const currentResults = await searchAgendaItems(db, {
     options: {
       ...filters,
-      minimumDate: (() => {
-        const d = new Date();
-        d.setHours(0, 0, 0, 0);
-        return d;
-      })(),
+      minimumDate: startOfToday,
       sortBy: 'relevance',
       sortDirection: 'descending',
     },

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -28,12 +28,12 @@ import { RequestToSpeakModal } from '@/components/deputation-modals/RequestToSpe
 import { allTags } from '@/constants/tags';
 import React from 'react';
 
+import { getStartOfToday } from '@/logic/date';
+
 function itemDateIsAfterToday(dateNumber: number): boolean {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0); // Reset to midnight
+  const today = getStartOfToday();
 
   const date = new Date(dateNumber);
-  date.setHours(0, 0, 0, 0);
 
   return date >= today;
 }
@@ -49,7 +49,6 @@ function DisplayTag({ tag, id }: { tag: string; id: number }) {
         <Chip
           className="hover:border-gray-400 hover:underline text-sm"
           variant="outline"
-          key={'chip' + id}
         >
           {tag.toLowerCase()}
         </Chip>
@@ -74,10 +73,11 @@ function AgendaItemCard({
   children,
 }: AgendaItemCardProps) {
   const formattedDate = new Date(item.meetingDate)
-    .toLocaleString('default', {
+    .toLocaleString('en-US', {
       month: 'short',
       year: 'numeric',
       day: 'numeric',
+      timeZone: 'America/Toronto',
     })
     .replace(',', '');
 

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -30,6 +30,13 @@ import React from 'react';
 
 import { getStartOfToday } from '@/logic/date';
 
+const cardDateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+  day: 'numeric',
+  timeZone: 'America/Toronto',
+});
+
 function itemDateIsAfterToday(dateNumber: number): boolean {
   const today = getStartOfToday();
 
@@ -49,6 +56,7 @@ function DisplayTag({ tag, id }: { tag: string; id: number }) {
         <Chip
           className="hover:border-gray-400 hover:underline text-sm"
           variant="outline"
+          key={'chip' + id}
         >
           {tag.toLowerCase()}
         </Chip>
@@ -72,13 +80,8 @@ function AgendaItemCard({
   externalLink,
   children,
 }: AgendaItemCardProps) {
-  const formattedDate = new Date(item.meetingDate)
-    .toLocaleString('en-US', {
-      month: 'short',
-      year: 'numeric',
-      day: 'numeric',
-      timeZone: 'America/Toronto',
-    })
+  const formattedDate = cardDateFormatter
+    .format(new Date(item.meetingDate))
     .replace(',', '');
 
   return (

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -109,14 +109,15 @@ export function DecisionBodyFilter({
   );
 }
 
+import { getStartOfToday } from '@/logic/date';
+
 export function UpcomingPastToggle() {
   type TimeRangeType = 'upcoming' | 'past';
   const { setSearchOptions } = useSearch();
   const updateItemsType = useCallback(
     (selectedRange: TimeRangeType) => {
       const isPast = selectedRange === 'past';
-      const startOfToday = new Date();
-      startOfToday.setHours(0, 0, 0, 0);
+      const startOfToday = getStartOfToday();
 
       setSearchOptions((opts) => ({
         ...opts,

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -115,12 +115,13 @@ export function UpcomingPastToggle() {
   const updateItemsType = useCallback(
     (selectedRange: TimeRangeType) => {
       const isPast = selectedRange === 'past';
-      const currentDate = new Date();
+      const startOfToday = new Date();
+      startOfToday.setHours(0, 0, 0, 0);
 
       setSearchOptions((opts) => ({
         ...opts,
-        minimumDate: isPast ? undefined : currentDate,
-        maximumDate: isPast ? currentDate : undefined,
+        minimumDate: isPast ? undefined : startOfToday,
+        maximumDate: isPast ? new Date(startOfToday.getTime() - 1) : undefined,
       }));
     },
     [setSearchOptions],

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -8,6 +8,7 @@ import { allTags, Tag, TagEnum } from '@/constants/tags';
 import { useSearch } from '@/contexts/SearchContext';
 import { logAnalytics } from '@/api/analytics';
 import { sortByFilterOptions } from '@/constants/sortByFilterOptions';
+import { getStartOfToday } from '@/logic/date';
 
 type DecisionBodyFilterProps = {
   decisionBodies: Record<string, DecisionBody>;
@@ -108,8 +109,6 @@ export function DecisionBodyFilter({
     />
   );
 }
-
-import { getStartOfToday } from '@/logic/date';
 
 export function UpcomingPastToggle() {
   type TimeRangeType = 'upcoming' | 'past';

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -25,15 +25,16 @@ const SearchContext = createContext<SearchContext | null>(null);
 
 type Props = React.PropsWithChildren;
 export function SearchProvider({ children }: Props) {
-  const [searchOptions, setSearchOptions] = useState<SearchOptions>({
-    textQuery: '',
-    tags: [],
-    decisionBodyIds: [],
-    minimumDate: (() => {
-      const d = new Date();
-      d.setHours(0, 0, 0, 0);
-      return d;
-    })(),
+  const [searchOptions, setSearchOptions] = useState<SearchOptions>(() => {
+    const startOfToday = new Date();
+    startOfToday.setHours(0, 0, 0, 0);
+
+    return {
+      textQuery: '',
+      tags: [],
+      decisionBodyIds: [],
+      minimumDate: startOfToday,
+    };
   });
 
   const [searchResults, setSearchResults] =

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -29,7 +29,11 @@ export function SearchProvider({ children }: Props) {
     textQuery: '',
     tags: [],
     decisionBodyIds: [],
-    minimumDate: new Date(),
+    minimumDate: (() => {
+      const d = new Date();
+      d.setHours(0, 0, 0, 0);
+      return d;
+    })(),
   });
 
   const [searchResults, setSearchResults] =

--- a/src/contexts/SearchContext.tsx
+++ b/src/contexts/SearchContext.tsx
@@ -12,6 +12,8 @@ import { fetchSearchResults, SearchOptions } from '@/logic/search';
 import type { AgendaItemSearchResponse } from '@/app/api/agenda-item/search/route';
 import { PAGE_LIMIT, SEARCH_DEBOUNCE_DELAY_MS } from '@/constants/search';
 
+import { getStartOfToday } from '@/logic/date';
+
 type SearchContext = {
   searchOptions: SearchOptions;
   setSearchOptions: Dispatch<SetStateAction<SearchOptions>>;
@@ -26,8 +28,7 @@ const SearchContext = createContext<SearchContext | null>(null);
 type Props = React.PropsWithChildren;
 export function SearchProvider({ children }: Props) {
   const [searchOptions, setSearchOptions] = useState<SearchOptions>(() => {
-    const startOfToday = new Date();
-    startOfToday.setHours(0, 0, 0, 0);
+    const startOfToday = getStartOfToday();
 
     return {
       textQuery: '',

--- a/src/logic/date.ts
+++ b/src/logic/date.ts
@@ -21,7 +21,7 @@ const torontoDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
   hour: 'numeric',
   minute: 'numeric',
   second: 'numeric',
-  hour12: false,
+  hourCycle: 'h23',
 });
 
 export const getStartOfToday = () => {
@@ -44,11 +44,8 @@ export const getStartOfToday = () => {
   const th = Number(torontoParts.find((p) => p.type === 'hour')!.value);
   const tmin = Number(torontoParts.find((p) => p.type === 'minute')!.value);
 
-  // Normalize hour (some environments return 24 instead of 0)
-  const hour = th === 24 ? 0 : th;
-
   // Calculate the offset in minutes
-  let diffMinutes = hour * 60 + tmin;
+  let diffMinutes = th * 60 + tmin;
   if (ty !== y || tm !== m || td !== d) {
     // If Toronto is on the previous day relative to UTC midnight, it's behind
     diffMinutes -= 24 * 60;

--- a/src/logic/date.ts
+++ b/src/logic/date.ts
@@ -1,0 +1,55 @@
+/**
+ * Returns a Date object representing the start of the current day (00:00:00)
+ * in the America/Toronto timezone.
+ *
+ * This is important because the TMMIS database stores meeting dates as
+ * timestamps corresponding to midnight in Toronto.
+ */
+export const getStartOfToday = () => {
+  const now = new Date();
+
+  // Get the current calendar date in Toronto
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Toronto',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+  const parts = formatter.formatToParts(now);
+  const y = Number(parts.find((p) => p.type === 'year')!.value);
+  const m = Number(parts.find((p) => p.type === 'month')!.value);
+  const d = Number(parts.find((p) => p.type === 'day')!.value);
+
+  // We want to find the UTC timestamp that corresponds to 00:00:00 on this day in Toronto.
+  // We do this by calculating the offset between UTC and Toronto at UTC midnight of that day.
+  const utcMidnight = new Date(Date.UTC(y, m - 1, d));
+  const torontoParts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'America/Toronto',
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+    hour12: false,
+  }).formatToParts(utcMidnight);
+
+  const ty = Number(torontoParts.find((p) => p.type === 'year')!.value);
+  const tm = Number(torontoParts.find((p) => p.type === 'month')!.value);
+  const td = Number(torontoParts.find((p) => p.type === 'day')!.value);
+  const th = Number(torontoParts.find((p) => p.type === 'hour')!.value);
+  const tmin = Number(torontoParts.find((p) => p.type === 'minute')!.value);
+
+  // Normalize hour (some environments return 24 instead of 0)
+  const hour = th === 24 ? 0 : th;
+
+  // Calculate the offset in minutes
+  let diffMinutes = hour * 60 + tmin;
+  if (ty !== y || tm !== m || td !== d) {
+    // If Toronto is on the previous day relative to UTC midnight, it's behind
+    diffMinutes -= 24 * 60;
+  }
+
+  // Midnight Toronto = UTC Midnight - Offset
+  return new Date(utcMidnight.getTime() - diffMinutes * 60000);
+};

--- a/src/logic/date.ts
+++ b/src/logic/date.ts
@@ -5,17 +5,30 @@
  * This is important because the TMMIS database stores meeting dates as
  * timestamps corresponding to midnight in Toronto.
  */
+
+const torontoDateFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Toronto',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+});
+
+const torontoDateTimeFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Toronto',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  second: 'numeric',
+  hour12: false,
+});
+
 export const getStartOfToday = () => {
   const now = new Date();
 
   // Get the current calendar date in Toronto
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Toronto',
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-  });
-  const parts = formatter.formatToParts(now);
+  const parts = torontoDateFormatter.formatToParts(now);
   const y = Number(parts.find((p) => p.type === 'year')!.value);
   const m = Number(parts.find((p) => p.type === 'month')!.value);
   const d = Number(parts.find((p) => p.type === 'day')!.value);
@@ -23,16 +36,7 @@ export const getStartOfToday = () => {
   // We want to find the UTC timestamp that corresponds to 00:00:00 on this day in Toronto.
   // We do this by calculating the offset between UTC and Toronto at UTC midnight of that day.
   const utcMidnight = new Date(Date.UTC(y, m - 1, d));
-  const torontoParts = new Intl.DateTimeFormat('en-US', {
-    timeZone: 'America/Toronto',
-    year: 'numeric',
-    month: 'numeric',
-    day: 'numeric',
-    hour: 'numeric',
-    minute: 'numeric',
-    second: 'numeric',
-    hour12: false,
-  }).formatToParts(utcMidnight);
+  const torontoParts = torontoDateTimeFormatter.formatToParts(utcMidnight);
 
   const ty = Number(torontoParts.find((p) => p.type === 'year')!.value);
   const tm = Number(torontoParts.find((p) => p.type === 'month')!.value);


### PR DESCRIPTION
## Description

Resolves #277 

My previous PR https://github.com/civic-dashboard/civic-dashboard-web/pull/370
Didn't seem to work entirely and still had items moving to past items before midnight, i believe it was due to not taking into account timezones properly.

## Testing instructions

During an evening we have agenda items/commitee meetings that are happening live, confirm items are not moved to "Past items"

Will need to wait for Monday or Tuesday to test it with the preiew link

## Checklist


- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
