### PR TITLE
Populate Agenda Item Categories (Tagging backend)

### DIFF
--- a/.github/workflows/seed_database.yml
+++ b/.github/workflows/seed_database.yml
@@ -32,4 +32,5 @@ jobs:
         run: npm ci
 
       - name: Run seed
+        # Because we do not use seed tracking, all scripts in /seeds are re-executed everytime we manually run this action
         run: npm run db:run-seed

--- a/seeds/1750790001580_AgendaItemCategories.ts
+++ b/seeds/1750790001580_AgendaItemCategories.ts
@@ -1,14 +1,21 @@
 import type { Kysely } from 'kysely';
 
 export async function seed(db: Kysely<any>): Promise<void> {
-  await db
+  // Performs a full backfill of categories based on existing subject terms.
+  // This ensures that all existing agenda items are correctly categorized.
+  const result = await db
     .insertInto('AgendaItemCategories')
     .expression((eb) =>
       eb
         .selectFrom('AgendaItemSubjectTerms as atst')
         .innerJoin('TagCategories as tc', 'atst.subjectTermSlug', 'tc.tagSlug')
-        .select(['atst.agendaItemId', 'tc.category']),
+        .select(['atst.agendaItemId', 'tc.category'])
+        .distinct(),
     )
     .onConflict((oc) => oc.columns(['agendaItemId', 'category']).doNothing())
-    .execute();
+    .executeTakeFirst();
+
+  console.log(
+    `Backfilled ${result.numInsertedOrUpdatedRows ?? 0} agenda item categories.`,
+  );
 }

--- a/src/database/pipelines/populateAgendaItems.ts
+++ b/src/database/pipelines/populateAgendaItems.ts
@@ -2,6 +2,7 @@ import { fetchAgendaItems } from '@/api/agendaItem';
 import {
   insertAgendaItems,
   insertAgendaItemSubjectTerms,
+  updateAgendaItemCategories,
 } from '@/database/queries/agendaItems';
 import { Kysely } from 'kysely';
 import { DB } from '@/database/allDbTypes';
@@ -28,7 +29,15 @@ export const populateAgendaItems = async (
       console.log(
         `${normalizedSubjectTerms.length} normalized subject terms found`,
       );
-      await insertAgendaItemSubjectTerms(db, normalizedSubjectTerms);
+      if (normalizedSubjectTerms.length > 0) {
+        await insertAgendaItemSubjectTerms(db, normalizedSubjectTerms);
+        //It only updates the categories for the specific agendaItemIds that were just fetched and inserted in that batch
+        const categoriesCount = await updateAgendaItemCategories(
+          db,
+          agendaItems.map((item) => item.agendaItemId),
+        );
+        console.log(`Updated ${categoriesCount} categories`);
+      }
     }
     console.log('inserted:', insertedCount);
 

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -156,6 +156,35 @@ export const insertAgendaItemSubjectTerms = async (
   });
 };
 
+export const updateAgendaItemCategories = async (
+  db: Kysely<DB>,
+  agendaItemIds?: number[],
+): Promise<number> => {
+  if (agendaItemIds && agendaItemIds.length === 0) {
+    return 0;
+  }
+
+  const result = await db
+    .insertInto('AgendaItemCategories')
+    .expression((eb) => {
+      let query = eb
+        .selectFrom('AgendaItemSubjectTerms as atst')
+        .innerJoin('TagCategories as tc', 'atst.subjectTermSlug', 'tc.tagSlug')
+        .select(['atst.agendaItemId', 'tc.category'])
+        .distinct();
+
+      if (agendaItemIds) {
+        query = query.where('atst.agendaItemId', 'in', agendaItemIds);
+      }
+
+      return query;
+    })
+    .onConflict((oc) => oc.columns(['agendaItemId', 'category']).doNothing())
+    .executeTakeFirst();
+
+  return Number(result?.numInsertedOrUpdatedRows ?? 0);
+};
+
 export function normalizeSubjectTerms(
   agendaItems: TMMISAgendaItem[] | AgendaItemForSubjectTerm[],
 ): AgendaItemSubjectTerm[] {
@@ -176,11 +205,9 @@ export function normalizeSubjectTerms(
 }
 
 export const processAgendaItemSubjectTerms = async (db: Kysely<DB>) => {
-  const deleteResult = await db
-    .deleteFrom('AgendaItemSubjectTerms')
-    .executeTakeFirst();
-  const deletedRows = deleteResult.numDeletedRows || 0;
-  console.log(`Deleted ${deletedRows} rows from AgendaItemSubjectTerms.`);
+  await sql`truncate table "AgendaItemCategories"`.execute(db);
+  await sql`truncate table "AgendaItemSubjectTerms"`.execute(db);
+  console.log('Truncated AgendaItemCategories and AgendaItemSubjectTerms.');
 
   // Fetch agenda items and process by batchSize sequentially
   let offset = 0;
@@ -207,8 +234,12 @@ export const processAgendaItemSubjectTerms = async (db: Kysely<DB>) => {
         db,
         normalizedSubjectTerms,
       );
+      const categoriesCount = await updateAgendaItemCategories(
+        db,
+        agendaItemRecords.map((r) => r.agendaItemId),
+      );
       console.log(
-        `Processed and inserted ${rowsInserted} subject terms for agenda items.`,
+        `Processed and inserted ${rowsInserted} subject terms and mapped ${categoriesCount} categories for agenda items.`,
       );
     } else {
       console.log('No subject terms to process for agenda items.');

--- a/src/scripts/processAgendaItemSubjectTerms.ts
+++ b/src/scripts/processAgendaItemSubjectTerms.ts
@@ -2,6 +2,10 @@ import { processAgendaItemSubjectTerms } from '@/database/queries/agendaItems';
 import { createDB } from '@/database/kyselyDb';
 
 // For the purpose of updating the subject terms in the database as a separate job
+// it's only called manually with npm run tsxe src/scripts/processAgendaItemSubjectTerms.ts , not done through an automatic job
+// only needed if subject terms need a full re-normalization, so it will clean out AgendaItemSubjectTerms and AgendaItemCategories
+// a reason to do that is if we change the assignment of subject terms to categories in TagCategories
+// Another reason would be if the normalization logic itself (how we turn "STREETS-AND-ROADS" into "streets and roads") were to change in src/database/pipelines/textParseUtils.ts.
 await processAgendaItemSubjectTerms(createDB());
 
 // so manually exit here, for consistency w/ other scripts


### PR DESCRIPTION
## Description

Resolves #373 

This is needed work to implement the new tagging backend

1 - Added `updateAgendaItemCategories` to handle mapping agenda items to categories via `AgendaItemSubjectTerms` and `TagCategories`.
   2 - Integrated category updates into the `populateAgendaItems` pipeline for real-time categorization during data ingestion.
   3 - Updated `processAgendaItemSubjectTerms` to truncate both subject terms and categories tables for more efficient full re-processing.
   4 - Enhanced the `AgendaItemCategories` seed to support a clean full backfill with deduplication.
   5 - Added documentation to the manual re-normalization script to clarify its role when category mappings or normalization logic changes.

## Testing instructions

Confirm in the database that AgendaItemCategories now gets populated with new items when running `.github/workflows/update_database.yml`

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [X ] This PR addresses all requirements described in the issue
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [X ] I have made corresponding changes to the documentation (if relevant)
