### PR TITLE
Synchronize councillor voting UI with action search results

### DIFF
--- a/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
+++ b/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
@@ -66,7 +66,7 @@ const AgendaItemCard = memo(function AgendaItemCard({
           <span className="font-bold">{firstMotion.committeeName}</span>
         </CardContent>
 
-        <CardContent className="flex-grow">
+        <CardContent className="flex-grow pb-0">
           <div className="relative max-h-[250px] overflow-hidden">
             <div
               className="absolute inset-0 h-[100px] top-[150px] bg-gradient-to-t from-white dark:from-neutral-800 from-1% via-transparent to-transparent pointer-events-none"

--- a/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
+++ b/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
@@ -8,13 +8,7 @@ import { MotionsList } from '@/app/councillors/[contactSlug]/components/MotionsL
 import { Button, buttonVariants } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Chip } from '@/components/ui/chip';
 import Link from 'next/link';
 import { cn } from '@/components/ui/utils';
@@ -69,7 +63,7 @@ const AgendaItemCard = memo(function AgendaItemCard({
         <CardContent className="flex-grow pb-0">
           <div className="relative max-h-[250px] overflow-hidden">
             <div
-              className="absolute inset-0 h-[100px] top-[150px] bg-gradient-to-t from-white dark:from-neutral-800 from-1% via-transparent to-transparent pointer-events-none"
+              className="absolute inset-0 h-[100px] top-[150px] bg-gradient-to-t from-white dark:from-neutral-800 from-1% via-transparent to-transparent pointer-events-none z-10"
               data-overflow-gradient
             />
             <div className="overflow-y-auto max-h-full">
@@ -92,21 +86,20 @@ const AgendaItemCard = memo(function AgendaItemCard({
               )}
             </div>
           </div>
+          <div className="flex justify-center mt-4 mb-4">
+            <Link
+              href={`/actions/item/${item.agendaItemNumber}`}
+              target="_blank"
+              className={cn(
+                buttonVariants({ variant: 'outline', size: 'sm' }),
+                'shadow-md hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors bg-white dark:bg-neutral-800',
+              )}
+            >
+              Learn more
+            </Link>
+          </div>
           <MotionsList motions={item.motions} />
         </CardContent>
-
-        <CardFooter>
-          <Link
-            href={`/actions/item/${item.agendaItemNumber}`}
-            target="_blank"
-            className={cn(
-              buttonVariants({ variant: 'outline', size: 'lg' }),
-              'grow sm:flex-initial hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors',
-            )}
-          >
-            Learn more
-          </Link>
-        </CardFooter>
       </Card>
     </div>
   );

--- a/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
+++ b/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
@@ -2,45 +2,112 @@
 
 import { AgendaItem } from '@/app/councillors/[contactSlug]/types';
 import { useMemo, memo, useState, useEffect } from 'react';
-import { Link2Icon } from 'lucide-react';
+import { Link2 } from 'lucide-react';
 import { SummaryPanel } from '@/app/councillors/[contactSlug]/components/SummaryPanel';
 import { MotionsList } from '@/app/councillors/[contactSlug]/components/MotionsList';
-import { AgendaItemLink } from '@/components/AgendaItemLink';
-import { buttonVariants, Button } from '@/components/ui/button';
+import { Button, buttonVariants } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
 import { useSearchParams } from 'next/navigation';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Chip } from '@/components/ui/chip';
+import Link from 'next/link';
+import { cn } from '@/components/ui/utils';
+import { sentenceCase } from '@/logic/strings';
 
 const AgendaItemCard = memo(function AgendaItemCard({
   item,
 }: {
   item: AgendaItem;
 }) {
+  const firstMotion = item.motions[0];
+  const dateString = firstMotion.dateTime?.substring(0, 10);
+  const date = dateString ? new Date(dateString) : new Date(NaN);
+  let formattedDate = 'Unknown date';
+
+  if (!isNaN(date.getTime())) {
+    date.setMinutes(date.getTimezoneOffset());
+    formattedDate = date
+      .toLocaleString('default', {
+        month: 'short',
+        year: 'numeric',
+        day: 'numeric',
+      })
+      .replace(/,/g, '');
+  }
+
   return (
-    <div className="flex flex-row mb-8">
-      <div className="border rounded-xl w-full">
-        <div className="flex justify-between border-b px-4 py-3">
-          <div className="border rounded-lg px-4 py-[10px] text-xs text-black font-semibold bg-[#a5f2d4]">
-            {formatDateString(item.motions[0].dateTime)}
+    <div className="mb-8 last:mb-0">
+      <Card className="transition-shadow h-full flex flex-col">
+        <CardHeader>
+          <div className="flex gap-x-2 items-center">
+            <Chip variant="green">{formattedDate}</Chip>
+            <span className="hidden sm:inline font-bold">
+              {firstMotion.committeeName}
+            </span>
           </div>
-          <AgendaItemLink
-            className={buttonVariants({ variant: 'default' })}
-            agendaItemNumber={item.agendaItemNumber}
-          >
-            <Link2Icon className="w-[14px] h-[14px] mr-2" />
-            {item.agendaItemNumber}
-          </AgendaItemLink>
-        </div>
-        <div className="px-4 pt-3">
-          <h3 className="font-semibold text-sm">{item.agendaItemTitle}</h3>
-          {item.agendaItemSummary && (
-            <SummaryPanel
-              originalSummary={item.agendaItemSummary}
-              aiSummary={item.aiSummary}
+          <Link href={`/actions/item/${item.agendaItemNumber}`} target="_blank">
+            <Chip
+              variant="outline"
+              className="hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors"
+            >
+              <Link2 size={14} />
+              {item.agendaItemNumber}
+            </Chip>
+          </Link>
+        </CardHeader>
+
+        <CardContent className="sm:hidden border-b border-neutral-100 dark:border-neutral-600 flex justify-center p-2">
+          <span className="font-bold">{firstMotion.committeeName}</span>
+        </CardContent>
+
+        <CardContent className="flex-grow">
+          <div className="relative max-h-[250px] overflow-hidden">
+            <div
+              className="absolute inset-0 h-[100px] top-[150px] bg-gradient-to-t from-white dark:from-neutral-800 from-1% via-transparent to-transparent pointer-events-none"
+              data-overflow-gradient
             />
-          )}
-        </div>
-        <MotionsList motions={item.motions} />
-      </div>
+            <div className="overflow-y-auto max-h-full">
+              <CardTitle className="text-lg mb-2">
+                {item.agendaItemTitle}
+              </CardTitle>
+              {item.itemStatus &&
+                item.itemStatus !== 'NO_ACTN' &&
+                item.itemStatus !== 'WO_RECS' && (
+                  <div className="mt-2 mb-2">
+                    <span className="font-bold">Status:</span>{' '}
+                    {sentenceCase(item.itemStatus)}
+                  </div>
+                )}
+              {item.agendaItemSummary && (
+                <SummaryPanel
+                  originalSummary={item.agendaItemSummary}
+                  aiSummary={item.aiSummary}
+                />
+              )}
+            </div>
+          </div>
+          <MotionsList motions={item.motions} />
+        </CardContent>
+
+        <CardFooter>
+          <Link
+            href={`/actions/item/${item.agendaItemNumber}`}
+            target="_blank"
+            className={cn(
+              buttonVariants({ variant: 'outline', size: 'lg' }),
+              'grow sm:flex-initial hover:bg-neutral-100 dark:hover:bg-neutral-700 transition-colors',
+            )}
+          >
+            Learn more
+          </Link>
+        </CardFooter>
+      </Card>
     </div>
   );
 });
@@ -314,17 +381,3 @@ export default function AgendaItemResults({
     </div>
   );
 }
-
-const formatDateString = (dateString: string) => {
-  if (!dateString) return dateString;
-  const date = new Date(dateString.substring(0, 10));
-  if (!date.getTime()) return dateString;
-  date.setMinutes(date.getTimezoneOffset());
-  return dateFormatter.format(date);
-};
-
-const dateFormatter = new Intl.DateTimeFormat('en-US', {
-  month: 'short',
-  day: 'numeric',
-  year: 'numeric',
-});

--- a/src/app/councillors/[contactSlug]/components/MotionsList.tsx
+++ b/src/app/councillors/[contactSlug]/components/MotionsList.tsx
@@ -76,7 +76,7 @@ export const MotionsList = ({ motions }: MotionsListProps) => {
         </div>
       ))}
       {needsPreviewToggle && (
-        <div className="border-t p-2 flex items-center justify-center">
+        <div className="border-t pt-1 pb-0 flex items-center justify-center">
           <Button variant="link" onClick={() => setShowAll(!showAll)}>
             {showAll
               ? 'Show less'

--- a/src/app/councillors/[contactSlug]/components/SummaryPanel.tsx
+++ b/src/app/councillors/[contactSlug]/components/SummaryPanel.tsx
@@ -2,10 +2,9 @@
 import { AiIndicator } from '@/components/AiIndicator';
 import { Markdown } from '@/components/Markdown';
 import { Button } from '@/components/ui/button';
-import { cn } from '@/components/ui/utils';
 import { sanitize } from '@/logic/sanitize';
 import { SparklesIcon } from 'lucide-react';
-import React, { FC, memo, useLayoutEffect, useRef, useState } from 'react';
+import React, { FC, memo, useState } from 'react';
 
 interface SummaryPanelProps {
   originalSummary: string;
@@ -18,11 +17,7 @@ export const SummaryPanel: FC<SummaryPanelProps> = ({
   const [tab, setTab] = useState<TabKind>(aiSummary ? 'ai' : 'original');
 
   if (!aiSummary) {
-    return (
-      <ExpandableText>
-        <SafeSummary summaryHtml={originalSummary} />
-      </ExpandableText>
-    );
+    return <SafeSummary summaryHtml={originalSummary} />;
   }
 
   return (
@@ -79,41 +74,5 @@ const SafeSummary = memo(function SafeSummary({
     />
   );
 });
-
-const ExpandableText: FC<{ children: React.ReactNode }> = ({ children }) => {
-  const ref = useRef<HTMLDivElement>(null);
-  const [isExpanded, setIsExpanded] = useState(false);
-  const [isExpansionNeeded, setIsExansionNeeded] = useState(false);
-
-  useLayoutEffect(() => {
-    const element = ref.current;
-    if (!element) return;
-    setIsExansionNeeded(element.scrollHeight > element.clientHeight);
-  }, []);
-
-  return (
-    <div>
-      <div
-        ref={ref}
-        className={cn('rich-html-styles overflow-hidden', {
-          'max-h-24 line-clamp-5 text-ellipsis': !isExpanded,
-        })}
-      >
-        {children}
-      </div>
-      <footer className="flex h-10 justify-end mt-2">
-        {(isExpansionNeeded || isExpanded) && (
-          <Button
-            onClick={() => setIsExpanded(!isExpanded)}
-            variant="ghost"
-            className="font-bold ml-auto"
-          >
-            {isExpanded ? 'Show less' : 'Show more'}
-          </Button>
-        )}
-      </footer>
-    </div>
-  );
-};
 
 type TabKind = 'ai' | 'original';

--- a/src/app/councillors/[contactSlug]/types.ts
+++ b/src/app/councillors/[contactSlug]/types.ts
@@ -3,6 +3,7 @@ export interface AgendaItem {
   agendaItemTitle: string;
   agendaItemSummary: string | null;
   aiSummary: string | null;
+  itemStatus: string | null;
   motions: Array<Motion>;
 }
 

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -56,7 +56,7 @@ type AgendaItemCardProps = React.PropsWithChildren<{
   item: AgendaItem;
   decisionBody: DecisionBody;
   externalLink?: string;
-  Footer?: () => React.ReactNode;
+  Footer: () => React.ReactNode;
   className?: string;
 }>;
 
@@ -74,8 +74,6 @@ function AgendaItemCard({
       day: 'numeric',
     })
     .replace(',', '');
-
-  const footerContent = Footer?.();
 
   return (
     <Card className={className}>
@@ -104,7 +102,9 @@ function AgendaItemCard({
       <CardContent className="[&_ul]:ml-8 [&_ul]:list-disc [&_td]:dark:!border-white">
         {children}
       </CardContent>
-      {footerContent && <CardFooter>{footerContent}</CardFooter>}
+      <CardFooter>
+        <Footer />
+      </CardFooter>
     </Card>
   );
 }
@@ -145,10 +145,9 @@ export function FullPageAgendaItemCard({
       item={item}
       decisionBody={decisionBody}
       externalLink={`https://secure.toronto.ca/council/agenda-item.do?item=${item.reference}`}
-      Footer={() => {
-        if (!isMeetingUpcomingOrToday) return null;
-        return (
-          <>
+      Footer={() => (
+        <>
+          {isMeetingUpcomingOrToday && (
             <SubmitCommentModal
               agendaItem={item}
               decisionBody={decisionBody}
@@ -163,6 +162,8 @@ export function FullPageAgendaItemCard({
                 </Button>
               }
             />
+          )}
+          {isMeetingUpcomingOrToday && (
             <RequestToSpeakModal
               agendaItem={item}
               decisionBody={decisionBody}
@@ -177,9 +178,9 @@ export function FullPageAgendaItemCard({
                 </Button>
               }
             />
-          </>
-        );
-      }}
+          )}
+        </>
+      )}
     >
       <CardTitle className="text-lg">{item.agendaItemTitle}</CardTitle>
       {item.itemStatus &&
@@ -340,16 +341,27 @@ export function SearchResultAgendaItemCard({
         item={item}
         decisionBody={decisionBody}
         className="transition-shadow sm:hover:shadow-xl dark:hover:bg-neutral-700 group"
-        Footer={() => {
-          if (!isMeetingUpcomingOrToday) return null;
-          return (
-            <TakeActionDropdown agendaItem={item} decisionBody={decisionBody} />
-          );
-        }}
+        Footer={() => (
+          <>
+            <Button
+              size="lg"
+              variant="outline"
+              className="grow sm:flex-initial"
+            >
+              Learn more
+            </Button>
+            {isMeetingUpcomingOrToday && (
+              <TakeActionDropdown
+                agendaItem={item}
+                decisionBody={decisionBody}
+              />
+            )}
+          </>
+        )}
       >
         <div className="relative max-h-[200px] overflow-hidden">
           <div
-            className="absolute inset-0 h-[100px] top-[100px] bg-gradient-to-t from-white dark:from-neutral-800 dark:group-hover:from-neutral-700 from-1% via-transparent to-transparent pointer-events-none z-10"
+            className="absolute inset-0 h-[100px] top-[100px] bg-gradient-to-t from-white dark:from-neutral-800 dark:group-hover:from-neutral-700 from-1% via-transparent to-transparent pointer-events-none"
             data-overflow-gradient
           />
           <div className="overflow-y-auto max-h-full">
@@ -370,15 +382,6 @@ export function SearchResultAgendaItemCard({
               />
             </HighlightChildren>
           </div>
-        </div>
-        <div className="flex justify-center mt-4 mb-4">
-          <Button
-            size="sm"
-            variant="outline"
-            className="shadow-sm bg-white dark:bg-neutral-800 group-hover:bg-neutral-100 dark:group-hover:bg-neutral-700"
-          >
-            Learn more
-          </Button>
         </div>
       </AgendaItemCard>
     </Link>

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -56,7 +56,7 @@ type AgendaItemCardProps = React.PropsWithChildren<{
   item: AgendaItem;
   decisionBody: DecisionBody;
   externalLink?: string;
-  Footer: () => React.ReactNode;
+  Footer?: () => React.ReactNode;
   className?: string;
 }>;
 
@@ -74,6 +74,8 @@ function AgendaItemCard({
       day: 'numeric',
     })
     .replace(',', '');
+
+  const footerContent = Footer?.();
 
   return (
     <Card className={className}>
@@ -102,9 +104,7 @@ function AgendaItemCard({
       <CardContent className="[&_ul]:ml-8 [&_ul]:list-disc [&_td]:dark:!border-white">
         {children}
       </CardContent>
-      <CardFooter>
-        <Footer />
-      </CardFooter>
+      {footerContent && <CardFooter>{footerContent}</CardFooter>}
     </Card>
   );
 }
@@ -145,9 +145,10 @@ export function FullPageAgendaItemCard({
       item={item}
       decisionBody={decisionBody}
       externalLink={`https://secure.toronto.ca/council/agenda-item.do?item=${item.reference}`}
-      Footer={() => (
-        <>
-          {isMeetingUpcomingOrToday && (
+      Footer={() => {
+        if (!isMeetingUpcomingOrToday) return null;
+        return (
+          <>
             <SubmitCommentModal
               agendaItem={item}
               decisionBody={decisionBody}
@@ -162,8 +163,6 @@ export function FullPageAgendaItemCard({
                 </Button>
               }
             />
-          )}
-          {isMeetingUpcomingOrToday && (
             <RequestToSpeakModal
               agendaItem={item}
               decisionBody={decisionBody}
@@ -178,9 +177,9 @@ export function FullPageAgendaItemCard({
                 </Button>
               }
             />
-          )}
-        </>
-      )}
+          </>
+        );
+      }}
     >
       <CardTitle className="text-lg">{item.agendaItemTitle}</CardTitle>
       {item.itemStatus &&
@@ -341,27 +340,16 @@ export function SearchResultAgendaItemCard({
         item={item}
         decisionBody={decisionBody}
         className="transition-shadow sm:hover:shadow-xl dark:hover:bg-neutral-700 group"
-        Footer={() => (
-          <>
-            <Button
-              size="lg"
-              variant="outline"
-              className="grow sm:flex-initial"
-            >
-              Learn more
-            </Button>
-            {isMeetingUpcomingOrToday && (
-              <TakeActionDropdown
-                agendaItem={item}
-                decisionBody={decisionBody}
-              />
-            )}
-          </>
-        )}
+        Footer={() => {
+          if (!isMeetingUpcomingOrToday) return null;
+          return (
+            <TakeActionDropdown agendaItem={item} decisionBody={decisionBody} />
+          );
+        }}
       >
         <div className="relative max-h-[200px] overflow-hidden">
           <div
-            className="absolute inset-0 h-[100px] top-[100px] bg-gradient-to-t from-white dark:from-neutral-800 dark:group-hover:from-neutral-700 from-1% via-transparent to-transparent pointer-events-none"
+            className="absolute inset-0 h-[100px] top-[100px] bg-gradient-to-t from-white dark:from-neutral-800 dark:group-hover:from-neutral-700 from-1% via-transparent to-transparent pointer-events-none z-10"
             data-overflow-gradient
           />
           <div className="overflow-y-auto max-h-full">
@@ -382,6 +370,15 @@ export function SearchResultAgendaItemCard({
               />
             </HighlightChildren>
           </div>
+        </div>
+        <div className="flex justify-center mt-4 mb-4">
+          <Button
+            size="sm"
+            variant="outline"
+            className="shadow-sm bg-white dark:bg-neutral-800 group-hover:bg-neutral-100 dark:group-hover:bg-neutral-700"
+          >
+            Learn more
+          </Button>
         </div>
       </AgendaItemCard>
     </Link>

--- a/src/logic/councillorItems.ts
+++ b/src/logic/councillorItems.ts
@@ -40,6 +40,14 @@ async function getTotalAgendaItemsForContact(
 ): Promise<{ itemCount: number }[]> {
   const agendaItemCount = db
     .selectFrom('Votes')
+    // Ensure we only count items that have TMMIS data (summaries)
+    .innerJoin('RawAgendaItemConsiderations', (eb) =>
+      eb.onRef(
+        'Votes.agendaItemNumber',
+        '=',
+        'RawAgendaItemConsiderations.reference',
+      ),
+    )
     .select((eb) => [
       eb.fn
         .count<number>('Votes.agendaItemNumber')
@@ -73,6 +81,14 @@ async function getVotesByAgendaItemsForContact(
             'AgendaItems.agendaItemNumber',
           ),
         )
+        // Ensure we only count items that have TMMIS data (summaries)
+        .innerJoin('RawAgendaItemConsiderations', (eb) =>
+          eb.onRef(
+            'Votes.agendaItemNumber',
+            '=',
+            'RawAgendaItemConsiderations.reference',
+          ),
+        )
         .select(['Votes.agendaItemNumber', 'Motions.dateTime'])
         .where('Votes.contactSlug', '=', contactSlug)
         .distinctOn('AgendaItems.agendaItemNumber')
@@ -88,7 +104,7 @@ async function getVotesByAgendaItemsForContact(
     .with('OriginalSummaries', (eb) =>
       eb
         .selectFrom('RawAgendaItemConsiderations')
-        .select(['reference', 'agendaItemSummary'])
+        .select(['reference', 'agendaItemSummary', 'itemStatus'])
         .distinct(),
     )
     .with('AutoSummaries', (eb) =>
@@ -118,7 +134,7 @@ async function getVotesByAgendaItemsForContact(
     .innerJoin('Committees', (eb) =>
       eb.onRef('Committees.committeeSlug', '=', 'Motions.committeeSlug'),
     )
-    .leftJoin('OriginalSummaries', (eb) =>
+    .innerJoin('OriginalSummaries', (eb) =>
       eb.onRef(
         'AgendaItems.agendaItemNumber',
         '=',
@@ -152,6 +168,7 @@ async function getVotesByAgendaItemsForContact(
       'Motions.result',
       'Motions.resultKind',
       'OriginalSummaries.agendaItemSummary',
+      'OriginalSummaries.itemStatus',
       sql<string>`CONCAT("Motions"."yesVotes", '-', "Motions"."noVotes")`.as(
         'tally',
       ),
@@ -164,6 +181,7 @@ async function getVotesByAgendaItemsForContact(
     agendaItemTitle,
     agendaItemSummary,
     aiSummary,
+    itemStatus,
     ...motion
   } of rows) {
     const agendaItem: AgendaItem = agendaItemByNumber.get(agendaItemNumber) ?? {
@@ -171,6 +189,7 @@ async function getVotesByAgendaItemsForContact(
       agendaItemTitle,
       agendaItemSummary,
       aiSummary,
+      itemStatus,
       motions: [],
     };
     agendaItem.motions.push(motion);


### PR DESCRIPTION

## Description
Resolves #151 

This bring the UI of the action search result page to the councillor page. This isn't meant to be a full UI revamp or a real improvement, it's just to make it more consistent between both AND allow the link to the "Learn more" (individual agenda item) which was missing entirely on the councillor page.

- Update councillor agenda item cards to use the standard Card-based UI for visual consistency with the main actions/search results page.
- Link to the "Learn more" individual agenda item page that we already had on the Actions page
- Implement a unified content overflow mechanism with a gradient fade, replacing the manual "Show more" logic in SummaryPanel.
- Modify councillorItems.ts logic to use innerJoin for city summaries, ensuring voting records are only displayed when official TMMIS summary data is available.
- Include itemStatus in the councillor data pipeline and display it using the sentenceCase utility.


Before:
<img width="917" height="826" alt="Screenshot 2026-04-02 at 10 02 19 PM" src="https://github.com/user-attachments/assets/b5c703c8-183b-479c-ba8e-dc18dabd08c1" />

After:
<img width="863" height="844" alt="Screenshot 2026-04-02 at 10 27 13 PM" src="https://github.com/user-attachments/assets/fda13ab9-f4f1-4b21-93fe-78c0df71b09f" />



## Testing instructions

Go on the Councillor page, click a councillor, click around to ensure everything works.

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
