### PR TITLE
fix: correct heading levels in GovernmentGuide.md

### DIFF
--- a/contents/markdown/GovernmentGuide.md
+++ b/contents/markdown/GovernmentGuide.md
@@ -1,33 +1,33 @@
 # City of Toronto Government Guide
-# City Council
+## City Council
 
 Toronto City Council is the decision-making body for the City of Toronto. It's made up of elected officials who vote on policies, laws, and initiatives that impact the city. These decisions affect everything from local parks to public transit and housing. See "Division of Powers" for more information about what municipal governments do!
 
-## Legislative and Executive Body
+### Legislative and Executive Body
 
 City Council is unique in the Canadian political landscape in that it is both a legislative and executive body. That means City Council does both executive work (hiring staff, directing staff to undertake certain work, overseeing the implementation of policy etc.) and legislative work (passing laws etc.) In the federal and provincial governments, these two functions of government are separate.
 
-## City Council Elections
+### City Council Elections
 
 Every four years, new councillors are elected. Elections can happen more frequently if there is a councillor vacancy that needs to be filled (e.g. if the councillor resigns).
 
-## City Council Terms
+### City Council Terms
 
 Toronto's City Council terms are four years long, after which elections are held to elect new Councillors across the city. The current term began on November 15, 2022, and will end on November 14, 2026.
 
-## (The lack of) Partisanship in Toronto Politics
+### (The lack of) Partisanship in Toronto Politics
 
 In Ontario, there are 4 major political parties: the NDP, Conservative, Liberal and Green party. In Toronto, councillors are not formally associated with political parties. Their policies and goals may still, however, align closely with certain parties. The Municipal Elections Act explicitly prohibits political parties within local municipal elections in Ontario.
 
-## Size of Council (Current and Historical)
+### Size of Council (Current and Historical)
 
 City Council is made up of 25 Councillors and one Mayor. Prior to September 2018, there were 47 Councillors on Council. The Provincial Ontario Government passed the Better Local Government Act (2018), reducing the number of wards and the size of Council to 25.
 
-# Division of Powers
+## Division of Powers
 
 When advocating for issues you care about, it is important to know which level of government has the authority to control or influence that issue. This is known as the "Division of Powers" in Canada. The Constitution assigns certain powers to federal (section 91) and provincial governments (section 92). Some examples include:
 
-## Powers of the Canadian (Federal) Government
+### Powers of the Canadian (Federal) Government
 
 - Federal Taxation
 - Regulation of Trade/Commerce
@@ -41,7 +41,7 @@ When advocating for issues you care about, it is important to know which level o
 - Marriage/Divorce
 - Criminal law, including Criminal Procedure
 
-## Powers of the Ontario (Provincial) Government
+### Powers of the Ontario (Provincial) Government
 
 - Provincial Taxation
 - Prisons
@@ -52,7 +52,7 @@ When advocating for issues you care about, it is important to know which level o
 - Education
 - Natural Resources
 
-## Powers of the City of Toronto
+### Powers of the City of Toronto
 
 It is important to note that the Constitution does not assign powers to municipalities. Municipalities are granted powers from the provincial governments they fall under, and provincial governments retain the right to give or take away municipal powers.
 
@@ -62,13 +62,13 @@ The City's responsibilities also include water treatment, parks, libraries, garb
 
 For additional information on the City of Toronto Act and similar legislation, please visit [this link](https://www.ontario.ca/laws/statute/06c11).
 
-# Wards
+## Wards
 
 Toronto is divided into 25 geographic areas, each represented by a City Councillor. These areas are called 'wards.' Residents living in each ward elect one councillor to represent the area in Municipal elections, which occur every four years. The next municipal election will be on October 26, 2026 - see the "Elections" section for more information.
 
 You can figure out what ward you live in by inputting your address here: [Ward Profiles – City of Toronto](https://www.toronto.ca/city-government/data-research-maps/neighbourhoods-communities/ward-profiles/).
 
-# Councillors
+## Councillors
 
 A Councillor is an elected official who represents a specific ward in Toronto. Councillors are responsible for voicing the concerns of their constituents, debating issues, and voting on decisions that shape the city's policies and laws.
 
@@ -86,35 +86,35 @@ Councillors wear two hats: they are working in the best interests of the city, a
 
 You can find a list of current City Councillors, along with details of their voting records, on our Councillors page.
 
-## City Councillor Offices and Staff
+### City Councillor Offices and Staff
 
 Each City Councillor has a team of staff who support them in their constituent and political work. These include assistants focused on constituency outreach and events, policy research, communications and administrative support. Councillors have physical offices located at City Hall, and many also have constituency offices located within their local communities. To find your Councillor's contact address, you can check their profile on the City Website.
 
-# Municipal Elections
+## Municipal Elections
 
-## Municipalities
+### Municipalities
 
 Municipalities are local governments (cities, towns, villages, townships, or counties) with elected Councillors and a Mayor. Ontario has 444 municipalities, managing local roads, waste, transit, zoning and libraries.
 
-## Municipal Elections
+### Municipal Elections
 
 City Councillors are elected in Municipal elections, which take place every four years on the fourth Monday in October. The next Municipal election will take place on **October 26, 2026**. Municipal elections take place on the same date across Ontario, when Councillors will be elected in Municipalities across the province.
 
 Ontario's Municipal Elections use a "first-past-the-post" system, in which the candidate with the most votes is elected, and all other votes do not result in representation.
 
-## By-Elections
+### By-Elections
 
 By-elections are held to fill vacancies on City Council that occur between general elections. Vacancies can occur due to a member's resignation, death, ineligibility to sit, or expulsion from their post.
 
 A by-election to fill the vacancy of Councillor for Ward 25, Scarborough-Rouge Park was held at the end of September 2025, where Neethan Shan was elected Councillor. He replaced Jennifer McKelvie, who was elected as a Member of Parliament in Ajax, Ontario in the 2025 Canadian Federal Election. As a result, Neethan Shan will hold the office for the remainder of the current City Council term, until the municipal elections on October 26th, 2026.
 
-## Election Contribution Rebate Program
+### Election Contribution Rebate Program
 
 The Contribution Rebate Program is available for people who contribute money to councillor or mayoral candidates in any election or by-election. The program allows contributors to receive a portion of their contribution(s) back.
 
 The amount of money that a contributor is eligible to receive is based on the total amount of money they contributed to all candidates participating in the program. For example, if a contributor gave three different candidates `$`500 each, their rebate is based on a total contribution of `$`1,500. See the "Rebate Amounts and Formula" section for examples of rebate calculations.
 
-## Voters' List
+### Voters' List
 
 The Voter's List is a list of the name, address and date of birth of all eligible voters across Ontario. It is used by election staff to verify whether voters are eligible to vote in a given election or by-election.
 


### PR DESCRIPTION
Demote section headings from h1 to h2 and sub-headings from h2 to h3, so that only the page title remains as the sole h1 heading. Closes #315

## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
Resolves #issue_number

<!-- 2. Give a high-level description of what this PR does. -->
<!-- What was the behaviour before? What should it be now? -->

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [ ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
