### PR TITLE
Rename Agenda Items Status  to more "friendly names"

### DIFF
--- a/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
+++ b/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
@@ -12,7 +12,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Chip } from '@/components/ui/chip';
 import Link from 'next/link';
 import { cn } from '@/components/ui/utils';
-import { sentenceCase } from '@/logic/strings';
+import { formatAgendaItemStatus } from '@/logic/strings';
 
 const AgendaItemCard = memo(function AgendaItemCard({
   item,
@@ -70,14 +70,12 @@ const AgendaItemCard = memo(function AgendaItemCard({
               <CardTitle className="text-lg mb-2">
                 {item.agendaItemTitle}
               </CardTitle>
-              {item.itemStatus &&
-                item.itemStatus !== 'NO_ACTN' &&
-                item.itemStatus !== 'WO_RECS' && (
-                  <div className="mt-2 mb-2">
-                    <span className="font-bold">Status:</span>{' '}
-                    {sentenceCase(item.itemStatus)}
-                  </div>
-                )}
+              {item.itemStatus && (
+                <div className="mt-2 mb-2">
+                  <span className="font-bold">Status:</span>{' '}
+                  {formatAgendaItemStatus(item.itemStatus)}
+                </div>
+              )}
               {item.agendaItemSummary && (
                 <SummaryPanel
                   originalSummary={item.agendaItemSummary}

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -27,7 +27,7 @@ import { SubmitCommentModal } from '@/components/deputation-modals/SubmitComment
 import { RequestToSpeakModal } from '@/components/deputation-modals/RequestToSpeakModal';
 import { allTags } from '@/constants/tags';
 import React from 'react';
-import { sentenceCase } from '@/logic/strings';
+import { formatAgendaItemStatus } from '@/logic/strings';
 
 import { getStartOfToday } from '@/logic/date';
 
@@ -186,14 +186,12 @@ export function FullPageAgendaItemCard({
       )}
     >
       <CardTitle className="text-lg">{item.agendaItemTitle}</CardTitle>
-      {item.itemStatus &&
-        item.itemStatus !== 'NO_ACTN' &&
-        item.itemStatus !== 'WO_RECS' && (
-          <div className="mt-2">
-            <span className="font-bold">Status:</span>{' '}
-            {sentenceCase(item.itemStatus)}
-          </div>
-        )}
+      {item.itemStatus && (
+        <div className="mt-2">
+          <span className="font-bold">Status:</span>{' '}
+          {formatAgendaItemStatus(item.itemStatus)}
+        </div>
+      )}
 
       {item.decisionRecommendations && (
         <>
@@ -370,15 +368,12 @@ export function SearchResultAgendaItemCard({
           <div className="overflow-y-auto max-h-full">
             <HighlightChildren terms={textQuery}>
               <CardTitle>{item.agendaItemTitle}</CardTitle>
-              {item.itemStatus &&
-                item.itemStatus !== 'NO_ACTN' &&
-                item.itemStatus !== 'WO_RECS' &&
-                !isMeetingUpcomingOrToday && (
-                  <div className="mt-2">
-                    <span className="font-bold">Status:</span>{' '}
-                    {sentenceCase(item.itemStatus)}
-                  </div>
-                )}
+              {item.itemStatus && !isMeetingUpcomingOrToday && (
+                <div className="mt-2">
+                  <span className="font-bold">Status:</span>{' '}
+                  {formatAgendaItemStatus(item.itemStatus)}
+                </div>
+              )}
               <div
                 className="mt-2"
                 dangerouslySetInnerHTML={{ __html: item.agendaItemSummary }}

--- a/src/logic/strings.ts
+++ b/src/logic/strings.ts
@@ -2,3 +2,26 @@ export const sentenceCase = (str: string): string => {
   if (!str) return '';
   return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase();
 };
+
+export const formatAgendaItemStatus = (
+  status: string | null | undefined,
+): string => {
+  if (!status) return '';
+
+  const statusMap: Record<string, string> = {
+    CONFRMED: 'Confirmed',
+    DEEMADPT: 'Deemed Adopted',
+    DEFERIND: 'Deferred Indefinitely',
+    INT_FAIL: 'Intro Failed',
+    NOQUORUM: 'No Quorum',
+    NOTADOPT: 'Not Adopted',
+    NO_ACTN: 'No Action is Required',
+    WO_RECS: 'Without Recommendations',
+    OOORDER: 'Out of Order',
+    POSTPONE: 'Deferred',
+    RESCIND: 'Rescinded',
+    WITHDRAW: 'Withdrawn',
+  };
+
+  return statusMap[status] || sentenceCase(status);
+};


### PR DESCRIPTION
## Description
Resolves #402 

Format agenda item status codes into human-readable strings

 - Added `formatAgendaItemStatus` utility in `src/logic/strings.ts` to map TMMIS status codes (e.g., DEEMADPT, DEFERIND) to readable equivalents.
- Updated `AgendaItemCard` and `AgendaItemResults` to use the new formatter.
- Removed filtering of 'NO_ACTN' and 'WO_RECS' statuses since they are now human-readable.
- Cleaned up unused `sentenceCase` imports.

## Testing instructions

Check on Councillor page and action page (in past items) and ensure the status of the item agendas is using the mapping values, not the raw values like before

## Checklist

- [ X] This PR addresses all requirements described in the issue
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ X] I have tested these changes in the preview deployment
- [X ] I have made corresponding changes to the documentation (if relevant)
