### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,0 @@
-src/app/actions @shrouxm
-src/api/agenda-item @shrouxm
-
-src/app/councillors @mattorchard
-
-src/app/how-council-works @sarmilan


### PR DESCRIPTION
Delete CODEOWNERS

The idea of it was great, but keeping it updated with the turnover of volunteers is too much trouble. Makes more sense to ask on Slack for who can review something and we can advise based on availability and current workload
