### PR TITLE
Strip span from agenda items summary and recs (avoid wrong text color during dark mode)

### DIFF
--- a/src/backend/emails/components/agendaItemCard.tsx
+++ b/src/backend/emails/components/agendaItemCard.tsx
@@ -1,4 +1,5 @@
 import { AgendaItem } from '@/database/queries/agendaItems';
+import { sanitize } from '@/logic/sanitize';
 import { Heading, Link, Section, Text } from '@react-email/components';
 
 export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
@@ -13,7 +14,7 @@ export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
       </Heading>
       <Text
         style={{ fontSize: '16px' }}
-        dangerouslySetInnerHTML={{ __html: item.agendaItemSummary }}
+        dangerouslySetInnerHTML={{ __html: sanitize(item.agendaItemSummary) }}
       />
     </Section>
   );

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -202,7 +202,7 @@ export function FullPageAgendaItemCard({
           <div
             className="mt-2"
             dangerouslySetInnerHTML={{
-              __html: sanitize(item.decisionRecommendations ?? ''),
+              __html: sanitize(item.decisionRecommendations),
             }}
           />
         </>

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -28,6 +28,7 @@ import { RequestToSpeakModal } from '@/components/deputation-modals/RequestToSpe
 import { allTags } from '@/constants/tags';
 import React from 'react';
 import { sentenceCase } from '@/logic/strings';
+import { sanitize } from '@/logic/sanitize';
 
 import { getStartOfToday } from '@/logic/date';
 
@@ -200,7 +201,9 @@ export function FullPageAgendaItemCard({
           <h4 className="mt-4 font-bold">Decision</h4>
           <div
             className="mt-2"
-            dangerouslySetInnerHTML={{ __html: item.decisionRecommendations }}
+            dangerouslySetInnerHTML={{
+              __html: sanitize(item.decisionRecommendations ?? ''),
+            }}
           />
         </>
       )}
@@ -212,7 +215,7 @@ export function FullPageAgendaItemCard({
           </h4>
           <div
             className="mt-2"
-            dangerouslySetInnerHTML={{ __html: item.decisionAdvice }}
+            dangerouslySetInnerHTML={{ __html: sanitize(item.decisionAdvice) }}
           />
         </>
       )}
@@ -229,7 +232,7 @@ export function FullPageAgendaItemCard({
       )}
       <div
         className="mt-2"
-        dangerouslySetInnerHTML={{ __html: item.agendaItemSummary }}
+        dangerouslySetInnerHTML={{ __html: sanitize(item.agendaItemSummary) }}
       />
 
       {item.agendaItemRecommendation && !item.decisionRecommendations && (
@@ -237,7 +240,9 @@ export function FullPageAgendaItemCard({
           <h4 className="mt-4 font-bold">Recommendations</h4>
           <div
             className="mt-2"
-            dangerouslySetInnerHTML={{ __html: item.agendaItemRecommendation }}
+            dangerouslySetInnerHTML={{
+              __html: sanitize(item.agendaItemRecommendation),
+            }}
           />
         </>
       )}
@@ -381,7 +386,9 @@ export function SearchResultAgendaItemCard({
                 )}
               <div
                 className="mt-2"
-                dangerouslySetInnerHTML={{ __html: item.agendaItemSummary }}
+                dangerouslySetInnerHTML={{
+                  __html: sanitize(item.agendaItemSummary),
+                }}
               />
             </HighlightChildren>
           </div>

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -10,7 +10,6 @@ const config: DOMPurifyConfig = {
     'ul',
     'ol',
     'li',
-    'span',
     'em',
     'sup',
     // 'a', // Todo: tricky since we ought to add rel, target, and class

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -16,6 +16,8 @@ const config: DOMPurifyConfig = {
     'tbody',
     'tr',
     'td',
+    'th',
+    'tfoot',
     // 'a', // Todo: tricky since we ought to add rel, target, and class
   ],
   ALLOWED_ATTR: ['title', 'style'],

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -1,5 +1,6 @@
-import DOMPurify from 'isomorphic-dompurify';
-import type { Config as DOMPurifyConfig } from 'dompurify';
+import DOMPurify, {
+  type Config as DOMPurifyConfig,
+} from 'isomorphic-dompurify';
 
 const config: DOMPurifyConfig = {
   ALLOWED_TAGS: [
@@ -26,9 +27,10 @@ const config: DOMPurifyConfig = {
 // Add a hook to sanitize the style attribute manually since we only want to remove color
 DOMPurify.addHook('uponSanitizeAttribute', (_node, event) => {
   if (event.attrName === 'style') {
-    const styles = event.attrValue.split(';').filter(Boolean);
-    const filteredStyles = styles
+    const filteredStyles = event.attrValue
+      .split(';')
       .map((style) => style.trim())
+      .filter(Boolean)
       .filter((style) => {
         const property = style.split(':')[0].trim().toLowerCase();
         return property !== 'color';

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -1,6 +1,5 @@
-import DOMPurify, {
-  type Config as DOMPurifyConfig,
-} from 'isomorphic-dompurify';
+import DOMPurify from 'isomorphic-dompurify';
+import type { Config as DOMPurifyConfig } from 'dompurify';
 
 const config: DOMPurifyConfig = {
   ALLOWED_TAGS: [
@@ -14,8 +13,32 @@ const config: DOMPurifyConfig = {
     'sup',
     // 'a', // Todo: tricky since we ought to add rel, target, and class
   ],
-  ALLOWED_ATTR: ['title'],
+  ALLOWED_ATTR: ['title', 'style'],
 };
+
+// Add a hook to sanitize the style attribute manually since we only want to allow padding
+DOMPurify.addHook('uponSanitizeAttribute', (_node, event) => {
+  if (event.attrName === 'style') {
+    const styles = event.attrValue.split(';').filter(Boolean);
+    const allowedStyles = styles
+      .map((style) => style.trim())
+      .filter((style) => {
+        const property = style.split(':')[0].trim().toLowerCase();
+        return (
+          property === 'padding' ||
+          property.startsWith('padding-') ||
+          property === 'margin' ||
+          property.startsWith('margin-')
+        );
+      });
+
+    if (allowedStyles.length > 0) {
+      event.attrValue = allowedStyles.join('; ') + ';';
+    } else {
+      event.keepAttr = false;
+    }
+  }
+});
 
 export const sanitize = (text: string) => {
   if (!text) return '';

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -11,29 +11,29 @@ const config: DOMPurifyConfig = {
     'li',
     'em',
     'sup',
+    'table',
+    'thead',
+    'tbody',
+    'tr',
+    'td',
     // 'a', // Todo: tricky since we ought to add rel, target, and class
   ],
   ALLOWED_ATTR: ['title', 'style'],
 };
 
-// Add a hook to sanitize the style attribute manually since we only want to allow padding
+// Add a hook to sanitize the style attribute manually since we only want to remove color
 DOMPurify.addHook('uponSanitizeAttribute', (_node, event) => {
   if (event.attrName === 'style') {
     const styles = event.attrValue.split(';').filter(Boolean);
-    const allowedStyles = styles
+    const filteredStyles = styles
       .map((style) => style.trim())
       .filter((style) => {
         const property = style.split(':')[0].trim().toLowerCase();
-        return (
-          property === 'padding' ||
-          property.startsWith('padding-') ||
-          property === 'margin' ||
-          property.startsWith('margin-')
-        );
+        return property !== 'color';
       });
 
-    if (allowedStyles.length > 0) {
-      event.attrValue = allowedStyles.join('; ') + ';';
+    if (filteredStyles.length > 0) {
+      event.attrValue = filteredStyles.join('; ') + ';';
     } else {
       event.keepAttr = false;
     }

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -19,9 +19,7 @@ const config: DOMPurifyConfig = {
 
 export const sanitize = (text: string) => {
   if (!text) return '';
-  const safeSummary = DOMPurify.sanitize(text, config);
-  if (!safeSummary) throw new Error(`No content after sanitizing`);
-  return safeSummary;
+  return DOMPurify.sanitize(text, config);
 };
 
 export const stripHtmlAndGetFirstParagraph = (html: string) => {


### PR DESCRIPTION
## Description
Resolves #408

Summary of changes:
   1. src/logic/sanitize.ts: Removed span from ALLOWED_TAGS in the DOMPurify configuration but also added all related table tags as they should not be sanitized
   2. src/components/AgendaItemCard.tsx:
       * Imported sanitize.
       * Applied sanitize() to item.decisionRecommendations, item.decisionAdvice, item.agendaItemSummary, and item.agendaItemRecommendation in FullPageAgendaItemCard.
       * Applied sanitize() to item.agendaItemSummary in SearchResultAgendaItemCard.
   3. src/backend/emails/components/agendaItemCard.tsx: Imported and applied sanitize() to item.agendaItemSummary.

  These changes ensure that all HTML content sourced from the database is properly sanitized before being rendered, stripping out span tags but also only removing the color if a tag like `<p>` has a style attribute. (It was too much trouble to try to stripe every styles, we use it for padding, height, etc)

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

Test with this action item: 2026.EP22.9 , 2026.EC27.2 and random action items to ensure everything displays well

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have performed a self-review of my code
- [ ] I have tested these changes in the preview deployment
- [ ] I have made corresponding changes to the documentation (if relevant)
