### PR TITLE
Set up new fonts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,15 +16,15 @@
 
 @layer base {
   h1 {
-    @apply text-4xl mb-2;
+    @apply text-4xl mb-2 font-heading font-extrabold;
   }
 
   h2 {
-    @apply text-2xl font-bold mb-2;
+    @apply text-2xl mb-2 font-heading font-bold;
   }
 
   body {
-    @apply bg-slate-200;
+    @apply bg-slate-200 font-body font-normal;
   }
 
   :root {
@@ -48,7 +48,6 @@ html {
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
 }
 
 .rich-html-styles ul {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,20 @@
 import type { Metadata } from 'next';
-import localFont from 'next/font/local';
-import '@/app/globals.css';
+import { Epilogue, IBM_Plex_Sans } from 'next/font/google';
 import Header from '@/components/navigation/Header';
 import Footer from '@/components/navigation/Footer';
+import '@/app/globals.css';
 
-const geistSans = localFont({
-  src: './fonts/GeistVF.woff',
-  variable: '--font-geist-sans',
-  weight: '100 900',
+const ibmPlexSans = IBM_Plex_Sans({
+  subsets: ['latin'],
+  weight: ['400', '500', '600', '700'],
+  display: 'swap',
+  variable: '--font-ibm-plex-sans',
 });
-const geistMono = localFont({
-  src: './fonts/GeistMonoVF.woff',
-  variable: '--font-geist-mono',
-  weight: '100 900',
+const epilogue = Epilogue({
+  subsets: ['latin'],
+  weight: ['700', '800'],
+  display: 'swap',
+  variable: '--font-epilogue',
 });
 
 export const metadata: Metadata = {
@@ -36,7 +38,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${ibmPlexSans.variable} ${epilogue.variable}`}>
       <head>
         <script
           defer
@@ -47,9 +49,7 @@ export default function RootLayout({
           data-exclude-hash="true"
         ></script>
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <Header />
         {children}
         <Footer />

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -39,6 +39,10 @@ const config: Config = {
       spacing: {
         'max-content-width': '814px',
       },
+      fontFamily: {
+        'heading': ['var(--font-epilogue)', 'sans-serif'],
+        'body': ['var(--font-ibm-plex-sans)', 'sans-serif'],
+      }
     },
   },
   plugins: [typography, require('tailwindcss-animate')],


### PR DESCRIPTION
## Description

This PR sets up new fonts for the site, and switches everything over to use it!  It extracts the font setup from #403.

| Before | After | 
|-|-|
| <img width="1458" height="3095" alt="image" src="https://github.com/user-attachments/assets/c7ca7291-a8c3-45bf-86ba-b933b5428a3c" />|<img width="1458" height="2775" alt="image" src="https://github.com/user-attachments/assets/332ed86e-35f6-4129-a053-8583afd8d1a3" />



## Testing instructions

Click around the preview site. Every page should be using the new fonts now, and nothing should look broken.

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
