### PR TITLE
Stop using deprecated Next.js image config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,8 +7,12 @@ const nextConfig = {
         hostname: 'www.toronto.ca',
         pathname: '/wp-content/uploads/**',
       },
+      {
+        protocol: 'https',
+        hostname: 'contrib.wp.intra.prod-toronto.ca',
+        pathname: '**',
+      },
     ],
-    domains: ['contrib.wp.intra.prod-toronto.ca'],
   },
   async redirects() {
     return [


### PR DESCRIPTION
## Description

This PR fixes the following deprecation warning when the project is started:

```
⚠ The "images.domains" configuration is deprecated. Please use "images.remotePatterns" configuration instead.
```


## Testing instructions

The preview site should build successfully and look normal.

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
