### PR TITLE
Update GitHub Actions and centralize Node.js version

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -13,11 +13,11 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:54320/civic_dashboard
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
 
       - name: Install dependencies
@@ -26,7 +26,7 @@ jobs:
       # i'm not sure why `npm run db:start` doesn't work here,
       # but the remaining commands can't connect to the DB without using this action
       - name: Start database
-        uses: hoverkraft-tech/compose-action@v2.2.0
+        uses: hoverkraft-tech/compose-action@v2
 
       - name: Run migrations
         run: npm run db:run-migrations

--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -23,8 +23,10 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # i'm not sure why `npm run db:start` doesn't work here,
+      # but the remaining commands can't connect to the DB without using this action
       - name: Start database
-        run: docker compose up -d database
+        uses: hoverkraft-tech/compose-action@v2
 
       - name: Run migrations
         run: npm run db:run-migrations
@@ -40,7 +42,3 @@ jobs:
 
       - name: Check that there is no diff
         run: git diff --exit-code
-
-      - name: Stop database
-        if: always()
-        run: docker compose down

--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -23,10 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # i'm not sure why `npm run db:start` doesn't work here,
-      # but the remaining commands can't connect to the DB without using this action
       - name: Start database
-        uses: hoverkraft-tech/compose-action@v2
+        run: docker compose up -d database
 
       - name: Run migrations
         run: npm run db:run-migrations
@@ -42,3 +40,7 @@ jobs:
 
       - name: Check that there is no diff
         run: git diff --exit-code
+
+      - name: Stop database
+        if: always()
+        run: docker compose down

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,14 +18,14 @@ jobs:
     name: Deploy frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,15 +11,15 @@ jobs:
     name: Lint
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -11,14 +11,14 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/notify_subscribers.yml
+++ b/.github/workflows/notify_subscribers.yml
@@ -11,14 +11,14 @@ jobs:
     name: Notify subscribers
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Create the required check as "in_progress" and store its ID
       - name: Mark check in_progress
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         id: start_check
         with:
           script: |
@@ -36,16 +36,16 @@ jobs:
             core.setOutput('check_id', res.data.id);
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .next/cache
           key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
@@ -80,7 +80,7 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: preview_url_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -88,7 +88,7 @@ jobs:
           body-includes: Preview
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.preview_url_comment.outputs.comment-id }}
@@ -100,7 +100,7 @@ jobs:
       # Update the same check run with success/failure
       - name: Mark check success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.checks.update({
@@ -118,7 +118,7 @@ jobs:
 
       - name: Mark check failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.checks.update({

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Create the required check as "in_progress" and store its ID
       - name: Mark check in_progress
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         id: start_check
         with:
           script: |
@@ -100,7 +100,7 @@ jobs:
       # Update the same check run with success/failure
       - name: Mark check success
         if: success()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.checks.update({
@@ -118,7 +118,7 @@ jobs:
 
       - name: Mark check failure
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.checks.update({

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR data
         id: pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         env:
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
@@ -37,7 +37,7 @@ jobs:
       # Create the check and save its ID for later update
       - name: Set "Upload preview deployment" check to in_progress
         id: start_check
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         with:
           script: |
             const res = await github.rest.checks.create({
@@ -117,7 +117,7 @@ jobs:
       # Update the same check run with success/failure
       - name: Set "Upload preview deployment" check to success
         if: success()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.checks.update({
@@ -135,7 +135,7 @@ jobs:
 
       - name: Set "Upload preview deployment" check to failure
         if: failure()
-        uses: actions/github-script@v9
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.checks.update({

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR data
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
@@ -37,7 +37,7 @@ jobs:
       # Create the check and save its ID for later update
       - name: Set "Upload preview deployment" check to in_progress
         id: start_check
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const res = await github.rest.checks.create({
@@ -55,7 +55,7 @@ jobs:
             core.setOutput('check_id', res.data.id);
 
       - name: Checkout PR HEAD (no persisted creds)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ steps.pr.outputs.repo_full_name }}
           ref: ${{ steps.pr.outputs.ref }}
@@ -63,13 +63,13 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
 
       - name: Restore Next.js cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .next/cache
           key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
@@ -97,7 +97,7 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         id: preview_url_comment
         with:
           issue-number: ${{ github.event.inputs.pr_number }}
@@ -105,7 +105,7 @@ jobs:
           body-includes: Preview
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.preview_url_comment.outputs.comment-id }}
@@ -117,7 +117,7 @@ jobs:
       # Update the same check run with success/failure
       - name: Set "Upload preview deployment" check to success
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.checks.update({
@@ -135,7 +135,7 @@ jobs:
 
       - name: Set "Upload preview deployment" check to failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.checks.update({

--- a/.github/workflows/refresh_subscription_queries.yml
+++ b/.github/workflows/refresh_subscription_queries.yml
@@ -13,14 +13,14 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/seed_database.yml
+++ b/.github/workflows/seed_database.yml
@@ -11,14 +11,14 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/update_contacts_votes.yml
+++ b/.github/workflows/update_contacts_votes.yml
@@ -15,14 +15,14 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -15,14 +15,14 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             .next/cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "@tailwindcss/typography": "^0.5.15",
         "@types/hash-sum": "1.0.2",
         "@types/mark.js": "^8.11.12",
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/nodemailer": "^6.4.17",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -13203,13 +13203,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.30.tgz",
-      "integrity": "sha512-7zf4YyHA+jvBNfVrk2Gtvs6x7E8V+YDW05bNfG2XkWDJfYRXrTiP/DsB2zSYTaHX0bGIujTBQdMVAhb+j7mwpg==",
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/node-fetch": {
@@ -24733,9 +24733,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@tailwindcss/typography": "^0.5.15",
     "@types/hash-sum": "1.0.2",
     "@types/mark.js": "^8.11.12",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/nodemailer": "^6.4.17",
     "@types/react": "^18",
     "@types/react-dom": "^18",


### PR DESCRIPTION

## Description
Resolves #389

Key Improvements:
   - Resolved Deprecation: All GitHub Actions (checkout, setup-node, cache, etc.) have been upgraded to their latest versions, which run on the Node.js 24 runtime as required by GitHub's upcoming policy.
   - Centralized Node Version: Replaced hardcoded node-version: '20'  with node-version-file: '.tool-versions'. GitHub Actions will now automatically use the version specified in our project's .tool-versions file, ensuring better synchronization between local development and CI/CD.

Meant to address this depreciation alert:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/ that we have been getting when executing our github actions

## Testing instructions

Will need to run the github actions manually through the branch first
And then we can validate that for the github actions that run from this branch, that they read from .tool-versions to know which node to use, and that they do not throw a warning about deprecation coming

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have performed a self-review of my code
- [ ] I have tested these changes in my local environment
- [X ] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
