### PR TITLE
Tidy up councillor pages

### DIFF
--- a/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
+++ b/src/app/councillors/[contactSlug]/components/AgendaItemResults.tsx
@@ -324,8 +324,8 @@ export default function AgendaItemResults({
     <div>
       {totalItems > 0 ? (
         <>
-          <div className="flex justify-between items-center mt-2 mb-8">
-            <div className="text-sm text-gray-600">
+          <div className="flex justify-between items-center mt-8 mb-4">
+            <div className="text-sm text-gray-500">
               {totalItems >= startIndex ? (
                 <>
                   Showing {startIndex}-{endIndex} of {totalItems} results
@@ -349,13 +349,8 @@ export default function AgendaItemResults({
         </>
       ) : (
         <>
-          <div className="flex justify-between items-center mt-2 mb-8">
-            <div className="text-sm text-gray-600">Loading...</div>
-          </div>
-          <div>
-            <div className="text-center py-8 text-gray-500">
-              Loading agenda items
-            </div>
+          <div className="text-center py-8 text-gray-500">
+            Loading agenda items...
           </div>
         </>
       )}

--- a/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
+++ b/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
@@ -92,10 +92,7 @@ export default function ContactBio({
           <dl className="grid grid-cols-[auto_1fr] gap-x-4 md:gap-y-1 text-left">
             <dt className="font-bold">Email</dt>
             <dd>
-              <a
-                className="classic-link"
-                href={`mailto:${contact.email}`}
-              >
+              <a className="classic-link" href={`mailto:${contact.email}`}>
                 {contact.email}
               </a>
             </dd>
@@ -104,10 +101,7 @@ export default function ContactBio({
               <>
                 <dt className="font-bold">Phone</dt>
                 <dd>
-                  <a
-                    className="classic-link"
-                    href={`tel:${contact.phone}`}
-                  >
+                  <a className="classic-link" href={`tel:${contact.phone}`}>
                     {contact.phone}
                   </a>
                 </dd>

--- a/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
+++ b/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
@@ -57,9 +57,9 @@ export default function ContactBio({
           </div>
         )}
 
-        <div className="space-y-4">
+        <div className="space-y-4 text-center md:text-left">
           <h1 className="text-3xl font-bold">{contact.contactName}</h1>
-          <div className="space-y-1">
+          <div className="md:space-y-1">
             {contact.role === 'Councillor' && (
               <p>
                 <ExternalLink
@@ -89,7 +89,7 @@ export default function ContactBio({
             )}
             {contact.role === 'Mayor' && <p>Mayor of Toronto</p>}
           </div>
-          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 md:gap-y-1 text-left">
             <dt className="font-bold">Email</dt>
             <dd>
               <a

--- a/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
+++ b/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
@@ -39,7 +39,7 @@ export default function ContactBio({
   }
 
   return (
-    <section className="m-8">
+    <section>
       <div className="flex flex-col md:flex-row gap-6 items-center">
         {showFallbackAvatar ? (
           <div className="w-48 h-48 light:bg-gray-200 rounded-full flex items-center justify-center">
@@ -49,7 +49,7 @@ export default function ContactBio({
           <div className="min-w-48 max-w-48 h-48 relative rounded-full overflow-hidden">
             <Image
               src={contact.photoUrl!}
-              alt={contact.contactName}
+              alt={`Photo of ${contact.contactName}`}
               fill
               className="object-cover object-top"
               onError={() => setShowFallbackAvatar(true)}
@@ -57,42 +57,43 @@ export default function ContactBio({
           </div>
         )}
 
-        <div>
-          <h1 className="text-3xl font-bold mb-2">{contact.contactName}</h1>
-          {contact.role === 'Councillor' && (
-            <p className="text-gray-600 dark:text-gray-300 mb-4">
-              <ExternalLink
-                href={councillorProfileURL}
-                className="classic-link"
-              >
-                Councillor Profile
-              </ExternalLink>
-            </p>
-          )}
-          {contact.role === 'Councillor' && (
-            <p className="text-gray-600 dark:text-gray-300 mb-4">
-              <ExternalLink href={wardURL} className="classic-link">
-                Ward {contact.wardId}, {contact.wardName}
-              </ExternalLink>
-            </p>
-          )}
-          {contact.role === 'Mayor' && (
-            <p className="text-gray-600 dark:text-gray-300 mb-4">
-              <ExternalLink
-                href="https://www.toronto.ca/city-government/council/office-of-the-mayor/"
-                className="classic-link"
-              >
-                Office of the Mayor
-              </ExternalLink>
-            </p>
-          )}
-          {contact.role === 'Mayor' && <p>Mayor of Toronto</p>}
-
-          <dl className="mt-4 grid grid-cols-[auto_1fr] gap-x-4 gap-y-2">
+        <div className="space-y-4">
+          <h1 className="text-3xl font-bold">{contact.contactName}</h1>
+          <div className="space-y-1">
+            {contact.role === 'Councillor' && (
+              <p>
+                <ExternalLink
+                  href={councillorProfileURL}
+                  className="classic-link"
+                >
+                  Councillor Profile
+                </ExternalLink>
+              </p>
+            )}
+            {contact.role === 'Councillor' && (
+              <p>
+                <ExternalLink href={wardURL} className="classic-link">
+                  Ward {contact.wardId}, {contact.wardName}
+                </ExternalLink>
+              </p>
+            )}
+            {contact.role === 'Mayor' && (
+              <p>
+                <ExternalLink
+                  href="https://www.toronto.ca/city-government/council/office-of-the-mayor/"
+                  className="classic-link"
+                >
+                  Office of the Mayor
+                </ExternalLink>
+              </p>
+            )}
+            {contact.role === 'Mayor' && <p>Mayor of Toronto</p>}
+          </div>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1">
             <dt className="font-bold">Email</dt>
             <dd>
               <a
-                className="text-blue-500 underline"
+                className="classic-link"
                 href={`mailto:${contact.email}`}
               >
                 {contact.email}
@@ -104,7 +105,7 @@ export default function ContactBio({
                 <dt className="font-bold">Phone</dt>
                 <dd>
                   <a
-                    className="text-blue-500 underline"
+                    className="classic-link"
                     href={`tel:${contact.phone}`}
                   >
                     {contact.phone}
@@ -120,7 +121,7 @@ export default function ContactBio({
         <h2 className="text-2xl font-bold mb-4">
           {contact.role === 'Mayor' ? 'Mayor' : 'Councillor'} Voting Record
         </h2>
-        <p className="text-gray-600 dark:text-gray-300 leading-relaxed">
+        <p>
           Here are all the past agenda items that the{' '}
           {contact.role === 'Mayor' ? 'mayor' : 'councillor'} has voted on
           during the current city council session. For each item, you may find

--- a/src/app/councillors/[contactSlug]/components/MotionsList.tsx
+++ b/src/app/councillors/[contactSlug]/components/MotionsList.tsx
@@ -39,7 +39,7 @@ export const MotionsList = ({ motions }: MotionsListProps) => {
   return (
     <div className="mt-2">
       {motionsToShow.map((motion) => (
-        <div key={motion.motionId} className="border-t p-4">
+        <div key={motion.motionId} className="border-t py-4 px-1">
           <dl className="flex mb-2 text-xs gap-1">
             <dt>Date</dt>
             <dd className="text-gray-500">{motion.dateTime}</dd>

--- a/src/app/councillors/[contactSlug]/page.tsx
+++ b/src/app/councillors/[contactSlug]/page.tsx
@@ -5,6 +5,7 @@ import CouncillorBio from '@/app/councillors/[contactSlug]/components/Councillor
 import CouncillorVoteContent from '@/app/councillors/[contactSlug]/components/CouncillorVoteContent';
 import { Kysely } from 'kysely';
 import { DB } from '@/database/allDbTypes';
+import { Page } from '@/components/ui/page';
 
 type ParamsType = {
   contactSlug: string;
@@ -97,12 +98,12 @@ export default async function CouncillorVotePage(props: {
     notFound();
   }
   return (
-    <main className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
+    <Page>
       <CouncillorBio contact={contact} />
       <CouncillorVoteContent
         currentPage={currentPage}
         contactSlug={contactSlug}
       />
-    </main>
+    </Page>
   );
 }

--- a/src/app/councillors/page.tsx
+++ b/src/app/councillors/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from 'next';
 import { createDB } from '@/database/kyselyDb';
 import { CouncillorListContainer } from '@/components/CouncillorListContainer';
 import { sql } from 'kysely';
+import { Page } from '@/components/ui/page';
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -71,8 +72,8 @@ export default async function CouncillorListPage() {
   const councillors = await listCouncillors();
 
   return (
-    <div className="max-w-screen-md mx-auto my-8 px-4">
+    <Page>
       <CouncillorListContainer councillors={councillors} />
-    </div>
+    </Page>
   );
 }

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-[13px] bg-white border sm:border-none dark:border-none border-[#d4d5d7] sm:shadow-lg text-neutral-950 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-50 ',
+      'rounded-[13px] bg-white border shadow-lg dark:shadow-none dark:border-none text-neutral-950 dark:bg-neutral-800 dark:text-neutral-50 ',
       className,
     )}
     {...props}


### PR DESCRIPTION
## Description

Fixes weird styling issues on councillor pages.

On the councillor list page:
- Uses the standard `Page` component so it has consistent page container styling with other pages.

| Before | After | 
|--|--|
| <img width="1566" height="1276" alt="image" src="https://github.com/user-attachments/assets/bb5dbdf5-41f0-416e-8fa1-0999e8041978" />|<img width="1549" height="1268" alt="image" src="https://github.com/user-attachments/assets/8c3083aa-e652-41ef-9b11-405411c5d769" />|

On the individual councillor pages:

- Fixes inconsistent vertical spacing between councillor title/links/contact info (1)
- Fixes misalignment between councillor info section and the action cards beneath (2)
- Reduces spacing under action item count, so it visually belongs with cards below rather than just floating on its own (3)
- Adds a light border to cards in light mode; I think the shadow isn't enough to distinguish the cards from the background. I'm aware that this style will probably be changed entirely in the upcoming redesign, but I'm fixing it since I'm already here!
- Fixes double loader for action items

| Before | After | 
|--|--|
| <img width="1550" height="1261" alt="image" src="https://github.com/user-attachments/assets/b5208d38-8371-4248-b547-763c79c1958a" />| <img width="1547" height="1282" alt="image" src="https://github.com/user-attachments/assets/4eb642f8-e0ca-4a4c-b3ec-c56dc52453af" />
| <img width="1545" height="1264" alt="image" src="https://github.com/user-attachments/assets/e09d2e76-deac-4a55-a0e3-215ac4cc8304" /> |<img width="1546" height="1252" alt="image" src="https://github.com/user-attachments/assets/83216cc8-ef5f-4ef6-bc11-21327b1c5068" />
| <img width="1632" height="853" alt="weird double loading" src="https://github.com/user-attachments/assets/48b34155-f4ad-40c0-b41c-98c32e63aa19" /> | <img width="1640" height="818" alt="new better loading" src="https://github.com/user-attachments/assets/d5c2e246-b149-4fe4-b24c-bf591fb8e3cf" />


On the _mobile_ individual councillor pages:
- Centers councillor info on small screens
- Reduces spacing around votes so they're less cramped

| Before | After | 
|--|--|
| <img width="492" height="1071" alt="image" src="https://github.com/user-attachments/assets/f999bc21-3219-45d6-9340-4e79cfb1e89d" />|<img width="498" height="1070" alt="image" src="https://github.com/user-attachments/assets/f4706d7a-67db-44c1-b287-0a7a95cf1ec6" />
| <img width="502" height="716" alt="image" src="https://github.com/user-attachments/assets/2a31f394-c5d8-4cc2-a77e-aecd3f19b255" />|<img width="511" height="686" alt="image" src="https://github.com/user-attachments/assets/5eedc46d-af55-405b-8c05-0d9bac2bc619" />




## Testing instructions

Open the preview site and go to the councillors page. Browse some councillors! Verify things look good.

Test on light vs dark mode, and on wide vs narrow screens too!

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
