### PR TITLE
Include search filters in subscription email subject lines

### DIFF
--- a/src/backend/emails/sendNewSubscriptionEmail.tsx
+++ b/src/backend/emails/sendNewSubscriptionEmail.tsx
@@ -5,15 +5,27 @@ import {
   NewSubscriptionEmail,
   NewSubscriptionEmailProps,
 } from '@/backend/emails/templates/newSubscription';
+import { getSearchFiltersDescription } from '@/logic/search';
+import { allTags } from '@/constants/tags';
+import { decisionBodies } from '@/constants/decisionBodies';
 
 type Args = {
   to: string | string[];
   props: NewSubscriptionEmailProps;
 };
 export async function sendNewSubscriptionEmail({ to, props }: Args) {
+  const filterDesc = getSearchFiltersDescription(
+    props.filters,
+    allTags,
+    decisionBodies,
+  );
+  const subject = filterDesc
+    ? `New subscription: ${filterDesc} on Civic Dashboard`
+    : 'New subscription on Civic Dashboard';
+
   return await sendEmail({
     from: 'Civic Dashboard <alerts@civicdashboard.ca>',
-    subject: 'New search subscription on Civic Dashboard',
+    subject,
     to,
     react: <NewSubscriptionEmail {...props} />,
   });

--- a/src/backend/emails/sendSubscriptionUpdateEmail.tsx
+++ b/src/backend/emails/sendSubscriptionUpdateEmail.tsx
@@ -5,15 +5,48 @@ import {
   SubscriptionUpdateEmailProps,
   SubscriptionUpdateEmail,
 } from '@/backend/emails/templates/subscriptionUpdate';
+import {
+  SubscribableSearchFilters,
+  getSearchFiltersDescription,
+} from '@/logic/search';
+import { allTags } from '@/constants/tags';
+import { decisionBodies } from '@/constants/decisionBodies';
 
 type Args = {
   to: string | string[];
   props: SubscriptionUpdateEmailProps;
 };
+
+function getSubject(filters: SubscribableSearchFilters[]): string {
+  if (filters.length === 0) {
+    return 'New subscription results from Civic Dashboard';
+  }
+
+  const firstFilterDesc = getSearchFiltersDescription(
+    filters[0],
+    allTags,
+    decisionBodies,
+  );
+  if (!firstFilterDesc) {
+    return 'New subscription results from Civic Dashboard';
+  }
+
+  let subject = `Subscription results: ${firstFilterDesc}`;
+  if (filters.length > 1) {
+    const otherCount = filters.length - 1;
+    subject += ` and ${otherCount} other subscription${
+      otherCount > 1 ? 's' : ''
+    }`;
+  }
+  subject += ' from Civic Dashboard';
+
+  return subject;
+}
+
 export async function sendSubscriptionUpdateEmail({ to, props }: Args) {
   return await sendEmail({
     from: 'Civic Dashboard <alerts@civicdashboard.ca>',
-    subject: 'New search subscription results from Civic Dashboard',
+    subject: getSubject(props.filters),
     to,
     react: <SubscriptionUpdateEmail {...props} />,
   });

--- a/src/backend/emails/templates/newSubscription.tsx
+++ b/src/backend/emails/templates/newSubscription.tsx
@@ -20,7 +20,7 @@ export const NewSubscriptionEmail = ({
   return (
     <EmailWrapper
       unsubscribeToken={unsubscribeToken}
-      previewText="New search subscription on Civic Dashboard."
+      previewText="New subscription on Civic Dashboard."
     >
       <Heading>
         This email has been subscribed to search results on{' '}

--- a/src/logic/search.ts
+++ b/src/logic/search.ts
@@ -43,6 +43,31 @@ export type SubscribableSearchFilters = {
   tags: TagEnum[];
 };
 
+export const getSearchFiltersDescription = (
+  filter: SubscribableSearchFilters,
+  allTags: Record<string, { displayName: string }>,
+  decisionBodies: Record<number, { decisionBodyName: string }>,
+) => {
+  const parts: string[] = [];
+  if (filter.textQuery) {
+    parts.push(`"${filter.textQuery}"`);
+  }
+  if (filter.tags.length > 0) {
+    const tagNames = filter.tags
+      .map((t) => allTags[t]?.displayName)
+      .filter(Boolean);
+    const joinedTags = tagNames.join(', ');
+    parts.push(filter.textQuery ? `about ${joinedTags}` : joinedTags);
+  }
+  if (filter.decisionBodyIds.length > 0) {
+    const dbNames = filter.decisionBodyIds
+      .map((id) => decisionBodies[id]?.decisionBodyName)
+      .filter(Boolean);
+    parts.push(`in ${dbNames.join(', ')}`);
+  }
+  return parts.join(' ');
+};
+
 export type TransientSearchFilters = {
   termId?: number;
   minimumDate?: Date;

--- a/src/logic/search.ts
+++ b/src/logic/search.ts
@@ -57,7 +57,7 @@ export const getSearchFiltersDescription = (
       .map((t) => allTags[t]?.displayName)
       .filter(Boolean);
     const joinedTags = tagNames.join(', ');
-    parts.push(filter.textQuery ? `about ${joinedTags}` : joinedTags);
+    parts.push(filter.textQuery ? `in ${joinedTags}` : joinedTags);
   }
   if (filter.decisionBodyIds.length > 0) {
     const dbNames = filter.decisionBodyIds


### PR DESCRIPTION
 Enhances email visibility by dynamically generating subject lines based on active search filters (keywords, tags, and decision bodies). This helps users distinguish between different subscription alerts at a glance.
   - Implemented `getSearchFiltersDescription` logic in `src/logic/search.ts`.
    - Updated new subscription and update emails to use descriptive subjects.

## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
Resolves #419 

## Testing instructions

This can be tested locally by going to: http://localhost:1080/ while subscribing to an email alert

## Checklist

- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ X] I have tested these changes in my local environment
- [ ] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
