### PR TITLE
Add link to our blog in footer and about page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -157,6 +157,13 @@ export default function About() {
             className="classic-link"
           >
             BlueSky
+          </ExternalLink>
+          , check out our{' '}
+          <ExternalLink
+            href="https://steady.page/en/civic-dashboard/posts"
+            className="classic-link"
+          >
+            blog
           </ExternalLink>{' '}
           or find us in the{' '}
           <ExternalLink

--- a/src/components/navigation/Footer.tsx
+++ b/src/components/navigation/Footer.tsx
@@ -112,6 +112,12 @@ export default function Footer() {
               >
                 Bluesky
               </ExternalLink>
+              <ExternalLink
+                href="https://steady.page/en/civic-dashboard/posts"
+                className="hover:text-blue-400 transition-colors duration-200"
+              >
+                Blog
+              </ExternalLink>
             </div>
 
             <Link


### PR DESCRIPTION
## Description

Resolves #110 

Footer and about us page will now link to our blog, since it was not linked anywhere


## Checklist


- [X ] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [X ] I have tested these changes in my local environment
- [ X] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
