### PR TITLE
Display list of committees on councillor page

### DIFF
--- a/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
+++ b/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
@@ -23,8 +23,10 @@ type MayorBioInfo = SharedBioInfo & {
 
 export default function ContactBio({
   contact,
+  committees,
 }: {
   contact: CouncillorBioInfo | MayorBioInfo;
+  committees: { decisionBodyId: number; decisionBodyName: string }[];
 }) {
   const [showFallbackAvatar, setShowFallbackAvatar] = useState(
     !contact.photoUrl,
@@ -104,6 +106,26 @@ export default function ContactBio({
                   <a className="classic-link" href={`tel:${contact.phone}`}>
                     {contact.phone}
                   </a>
+                </dd>
+              </>
+            )}
+
+            {committees.length > 0 && (
+              <>
+                <dt className="font-bold">Committees & Boards</dt>
+                <dd>
+                  <ul className="list-none p-0 m-0">
+                    {committees.map((committee) => (
+                      <li key={committee.decisionBodyId}>
+                        <ExternalLink
+                          href={`https://secure.toronto.ca/council/#/committees/${committee.decisionBodyId}`}
+                          className="classic-link"
+                        >
+                          {committee.decisionBodyName}
+                        </ExternalLink>
+                      </li>
+                    ))}
+                  </ul>
                 </dd>
               </>
             )}

--- a/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
+++ b/src/app/councillors/[contactSlug]/components/CouncillorBio.tsx
@@ -42,7 +42,7 @@ export default function ContactBio({
 
   return (
     <section>
-      <div className="flex flex-col md:flex-row gap-6 items-center">
+      <div className="flex flex-col md:flex-row gap-6 items-center md:items-start">
         {showFallbackAvatar ? (
           <div className="w-48 h-48 light:bg-gray-200 rounded-full flex items-center justify-center">
             <CircleUserRound size={190} />

--- a/src/app/councillors/[contactSlug]/page.tsx
+++ b/src/app/councillors/[contactSlug]/page.tsx
@@ -6,6 +6,8 @@ import CouncillorVoteContent from '@/app/councillors/[contactSlug]/components/Co
 import { Kysely } from 'kysely';
 import { DB } from '@/database/allDbTypes';
 import { Page } from '@/components/ui/page';
+import { decisionBodies } from '@/constants/decisionBodies';
+import { CURRENT_COUNCIL_TERM } from '@/constants/currentCouncilTerm';
 
 type ParamsType = {
   contactSlug: string;
@@ -99,9 +101,29 @@ export default async function CouncillorVotePage(props: {
   if (!contact) {
     notFound();
   }
+
+  const committees = Object.values(decisionBodies)
+    .filter(
+      (body) =>
+        body.termId === CURRENT_COUNCIL_TERM &&
+        //Everyone is already part of council so we don't want to just list "City Council"
+        body.decisionBodyPublishLabelCd !== 'COUNCIL' &&
+        //Not an ideal matching technique but we get our list of contacts (councillors/mayor) from OpenData (which has no ID) vs the committee data which comes from TMMIS
+        body.members.some(
+          (m) =>
+            `${m.firstName.trim()} ${m.lastName.trim()}` ===
+            contact.contactName.trim(),
+        ),
+    )
+    .map((c) => ({
+      decisionBodyId: c.decisionBodyId,
+      decisionBodyName: c.decisionBodyName,
+    }))
+    .sort((a, b) => a.decisionBodyName.localeCompare(b.decisionBodyName));
+
   return (
     <Page>
-      <CouncillorBio contact={contact} />
+      <CouncillorBio contact={contact} committees={committees} />
       <CouncillorVoteContent
         currentPage={currentPage}
         contactSlug={contactSlug}


### PR DESCRIPTION


## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
Resolves #317 
Related to #381 

<!-- 2. Give a high-level description of what this PR does. -->
Display committees and boards on councillor profile pages 
Filter and match councillor names against `decisionBodies` data for the current term
Add a "Committees & Boards" section to the councillor bio component 
Link each committee to its respective TMMIS page
Sort committees alphabetically by name

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->
<img width="949" height="553" alt="Screenshot 2026-05-02 at 11 44 59 PM" src="https://github.com/user-attachments/assets/e756e7f6-674d-401b-b041-e577e03427e7" />

## Testing instructions

Go to multiple councillor pages

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [ X] This PR addresses all requirements described in the issue
- [ X] I have commented my code, particularly in hard-to-understand areas
- [X ] I have performed a self-review of my code
- [ X] I have tested these changes in my local environment
- [ X] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
