### PR TITLE
db: implement connection singleton to prevent exhaustion

### DIFF
--- a/src/database/kyselyDb.ts
+++ b/src/database/kyselyDb.ts
@@ -2,19 +2,29 @@ import { Kysely } from 'kysely';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import { createPostgres } from '@/database/psql';
 import { DB } from '@/database/allDbTypes';
+import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants';
 
 const globalForDb = globalThis as unknown as {
   __kysely_db__: Kysely<DB> | undefined;
 };
 
 export const createDB = () => {
-  // Use a singleton for all phases (Build, Dev, Prod).
-  // should fix connection exhaustion crashes during runtime.
-  if (globalForDb.__kysely_db__) return globalForDb.__kysely_db__;
+  // Use a singleton in non-production environments (Dev, Test)
+  // OR during the production build phase (Static Generation).
+  // In production runtime (e.g. Cloudflare Workers), we revert to standard instantiation
+  // to avoid environment-specific issues with global singletons.
+  if (
+    process.env.NODE_ENV !== 'production' ||
+    process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD
+  ) {
+    if (globalForDb.__kysely_db__) return globalForDb.__kysely_db__;
 
-  const db = createNewDb();
-  globalForDb.__kysely_db__ = db;
-  return db;
+    const db = createNewDb();
+    globalForDb.__kysely_db__ = db;
+    return db;
+  }
+
+  return createNewDb();
 };
 
 const createNewDb = () => {

--- a/src/database/kyselyDb.ts
+++ b/src/database/kyselyDb.ts
@@ -2,18 +2,19 @@ import { Kysely } from 'kysely';
 import { PostgresJSDialect } from 'kysely-postgres-js';
 import { createPostgres } from '@/database/psql';
 import { DB } from '@/database/allDbTypes';
-import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants';
 
-const isDuringBuild = () => process.env.NEXT_PHASE === PHASE_PRODUCTION_BUILD;
-
-let buildTimeDb: Kysely<DB> | null = null;
+const globalForDb = globalThis as unknown as {
+  __kysely_db__: Kysely<DB> | undefined;
+};
 
 export const createDB = () => {
-  if (isDuringBuild()) {
-    buildTimeDb ??= createNewDb();
-    return buildTimeDb;
-  }
-  return createNewDb();
+  // Use a singleton for all phases (Build, Dev, Prod).
+  // should fix connection exhaustion crashes during runtime.
+  if (globalForDb.__kysely_db__) return globalForDb.__kysely_db__;
+
+  const db = createNewDb();
+  globalForDb.__kysely_db__ = db;
+  return db;
 };
 
 const createNewDb = () => {


### PR DESCRIPTION


## Description
Resolves #427

Refactor `createDB` to use a global singleton pattern via `globalThis`. This ensures the Kysely instance and its underlying connection pool are  reused in DEV (but not production), preventing "too many connections" errors. Before, it was only doing it during build

## Testing instructions

Can only be tested locally by clicking on a bunch of councillor page one by one

## Checklist


- [X ] This PR addresses all requirements described in the issue
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ X] I have tested these changes in my local environment
- [ X] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
