### PR TITLE
Pin versions for Github actions

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -26,7 +26,7 @@ jobs:
       # i'm not sure why `npm run db:start` doesn't work here,
       # but the remaining commands can't connect to the DB without using this action
       - name: Start database
-        uses: hoverkraft-tech/compose-action@v2
+        uses: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a # v2.6.0
 
       - name: Run migrations
         run: npm run db:run-migrations

--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -13,7 +13,7 @@ jobs:
       DATABASE_URL: postgresql://postgres:postgres@localhost:54320/civic_dashboard
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
     name: Deploy frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           cache: npm
 
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     name: Lint
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -11,7 +11,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -18,7 +18,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/migrate_database.yml
+++ b/.github/workflows/migrate_database.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/notify_subscribers.yml
+++ b/.github/workflows/notify_subscribers.yml
@@ -18,7 +18,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/notify_subscribers.yml
+++ b/.github/workflows/notify_subscribers.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/notify_subscribers.yml
+++ b/.github/workflows/notify_subscribers.yml
@@ -11,7 +11,7 @@ jobs:
     name: Notify subscribers
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -36,7 +36,7 @@ jobs:
             core.setOutput('check_id', res.data.id);
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
         uses: actions/setup-node@v6

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -45,7 +45,7 @@ jobs:
           cache: npm
 
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .next/cache
           key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # Create the required check as "in_progress" and store its ID
       - name: Mark check in_progress
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         id: start_check
         with:
           script: |
@@ -100,7 +100,7 @@ jobs:
       # Update the same check run with success/failure
       - name: Mark check success
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.checks.update({
@@ -118,7 +118,7 @@ jobs:
 
       - name: Mark check failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.checks.update({

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -80,7 +80,7 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: preview_url_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
@@ -88,7 +88,7 @@ jobs:
           body-includes: Preview
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.preview_url_comment.outputs.comment-id }}

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -69,7 +69,7 @@ jobs:
           cache: npm
 
       - name: Restore Next.js cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .next/cache
           key: ${{ runner.os }}-frontend-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -97,7 +97,7 @@ jobs:
           echo "preview_url=$preview_url" >> "$GITHUB_OUTPUT"
 
       - name: Find Comment
-        uses: peter-evans/find-comment@v4
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: preview_url_comment
         with:
           issue-number: ${{ github.event.inputs.pr_number }}
@@ -105,7 +105,7 @@ jobs:
           body-includes: Preview
 
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@v5
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           comment-id: ${{ steps.preview_url_comment.outputs.comment-id }}

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Get PR data
         id: pr
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
@@ -37,7 +37,7 @@ jobs:
       # Create the check and save its ID for later update
       - name: Set "Upload preview deployment" check to in_progress
         id: start_check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const res = await github.rest.checks.create({
@@ -117,7 +117,7 @@ jobs:
       # Update the same check run with success/failure
       - name: Set "Upload preview deployment" check to success
         if: success()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.checks.update({
@@ -135,7 +135,7 @@ jobs:
 
       - name: Set "Upload preview deployment" check to failure
         if: failure()
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.checks.update({

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -55,7 +55,7 @@ jobs:
             core.setOutput('check_id', res.data.id);
 
       - name: Checkout PR HEAD (no persisted creds)
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ steps.pr.outputs.repo_full_name }}
           ref: ${{ steps.pr.outputs.ref }}

--- a/.github/workflows/preview_manual.yml
+++ b/.github/workflows/preview_manual.yml
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 1
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/refresh_subscription_queries.yml
+++ b/.github/workflows/refresh_subscription_queries.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/refresh_subscription_queries.yml
+++ b/.github/workflows/refresh_subscription_queries.yml
@@ -13,7 +13,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/refresh_subscription_queries.yml
+++ b/.github/workflows/refresh_subscription_queries.yml
@@ -20,7 +20,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/seed_database.yml
+++ b/.github/workflows/seed_database.yml
@@ -11,7 +11,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/seed_database.yml
+++ b/.github/workflows/seed_database.yml
@@ -18,7 +18,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/seed_database.yml
+++ b/.github/workflows/seed_database.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/update_contacts_votes.yml
+++ b/.github/workflows/update_contacts_votes.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/update_contacts_votes.yml
+++ b/.github/workflows/update_contacts_votes.yml
@@ -15,7 +15,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/update_contacts_votes.yml
+++ b/.github/workflows/update_contacts_votes.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version-file: '.tool-versions'
           cache: npm

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -15,7 +15,7 @@ jobs:
       DATABASE_URL: ${{ secrets.DATABASE_URL }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/update_database.yml
+++ b/.github/workflows/update_database.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: '.tool-versions'
           cache: npm
       - name: Restore cache
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             .next/cache


### PR DESCRIPTION
## Description

Supply chain attacks are frequent nowadays. Our npm dependencies are pinned down via package-lock.json, but the Github actions we use are not pinned at all. We reference them by their major version number, e.g. `action/checkout@v6`, which means that each time we run the action (for example, when we create or merge a PR), it fetches the latest version of that action each time. If the action has been compromised, then the latest version could execute malicious code.

Pinning Github actions is as simple as referencing the commit SHA of the desired version, instead of the tagged version number. I've included the version number as a comment beside each SHA.

You can read more about this method here: https://dev.to/nicolasv/github-actions-why-you-should-pin-your-actions-to-a-specific-version-1513 As a side note, they also recommended enabling the "Require SHA" option in Github orgs. I think we should do that too!

## Testing instructions

CI should run successfully. 

For code review, I recommend reviewing by commit. You can reference these release tags and their commit SHAs:

- https://github.com/hoverkraft-tech/compose-action/releases/tag/v2.6.0
- https://github.com/peter-evans/create-or-update-comment/releases/tag/v5.0.0
- https://github.com/peter-evans/find-comment/releases/tag/v4.0.0
- https://github.com/actions/checkout/releases/tag/v6.0.2
- https://github.com/actions/setup-node/releases/tag/v6.4.0
- https://github.com/actions/cache/releases/tag/v5.0.5
- https://github.com/actions/github-script/releases/tag/v8

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
