### PR TITLE
Github actions started failing after the hyperdrive PR 

### DIFF
--- a/src/database/kyselyDb.ts
+++ b/src/database/kyselyDb.ts
@@ -5,6 +5,9 @@ import { DB } from '@/database/allDbTypes';
 import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants';
 import React from 'react';
 
+// React.cache is only available in the Next.js runtime.
+// Standalone scripts (like updateDatabase) will fail (The requested module 'react' does not provide an export named 'cache')
+// if we try to use it directly. This fallback ensures compatibility across both.
 const cache =
   (React as unknown as { cache?: <T>(fn: T) => T }).cache ||
   (<T>(fn: T): T => fn);
@@ -36,7 +39,8 @@ export const createDB = cache(() => {
     return db;
   }
 
-  // In production runtime (Cloudflare Workers), React.cache handles the singleton
-  // scope per request, avoiding stale context issues of global singletons.
+  // In production runtime (Cloudflare Workers), we avoid global singletons to prevent
+  // connection leaks or stale state between requests. React.cache provides a
+  // request-scoped singleton, ensuring only one DB instance is created per request.
   return createNewDb();
 });

--- a/src/database/kyselyDb.ts
+++ b/src/database/kyselyDb.ts
@@ -3,7 +3,11 @@ import { PostgresJSDialect } from 'kysely-postgres-js';
 import { createPostgres } from '@/database/psql';
 import { DB } from '@/database/allDbTypes';
 import { PHASE_PRODUCTION_BUILD } from 'next/dist/shared/lib/constants';
-import { cache } from 'react';
+import React from 'react';
+
+const cache =
+  (React as unknown as { cache?: <T>(fn: T) => T }).cache ||
+  (<T>(fn: T): T => fn);
 
 const globalForDb = globalThis as unknown as {
   __kysely_db__: Kysely<DB> | undefined;


### PR DESCRIPTION
This is what happened after the last PR got merged #430 
<img width="1125" height="332" alt="Screenshot 2026-05-14 at 6 40 45 PM" src="https://github.com/user-attachments/assets/a8cc079c-44c3-4f37-bb59-caa6f55d8801" />

Error was:
```
Run npm run tsx src/scripts/repopulateRawContactsAndVotes.ts

> civic-dashboard-web@0.1.0 tsx
> tsx --tsconfig=tsconfig.tsx.json src/scripts/repopulateRawContactsAndVotes.ts

/home/runner/work/civic-dashboard-web/civic-dashboard-web/src/database/kyselyDb.ts:6
import { cache } from 'react';
         ^

SyntaxError: The requested module 'react' does not provide an export named 'cache'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:182:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:266:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:644:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5)

```

This PR aims to fix that


Fixes a SyntaxError when running standalone scripts (like database repopulation) because 'cache' is not a standard named export in React 18 outside of the Next.js runtime. Use a defensive check for React.cache with a no-op fallback. Maintains request-scoped caching in Next.js/Cloudflare Workers.



## Testing instructions

Test executing those failing script from that new branch (427hyperdrive-fix)

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [ ] This PR addresses all requirements described in the issue
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ X] I have tested these changes in my local environment
- [X ] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
