### PR TITLE
Fix scroll behaviour on decision body filter

### DIFF
--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -106,6 +106,7 @@ export function DecisionBodyFilter({
       value={decisionBodyIds}
       onSelect={onSelect}
       placeholder="Select decision body..."
+      scrollToTopOnSearch
     />
   );
 }

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -63,7 +63,7 @@ export function SortDropdown() {
       placeholder="Sort by..."
       multiple={false}
       searchable={false}
-      reorderSelected={false}
+      reorderListItems={false}
     />
   );
 }
@@ -106,7 +106,6 @@ export function DecisionBodyFilter({
       value={decisionBodyIds}
       onSelect={onSelect}
       placeholder="Select decision body..."
-      scrollToTopOnSearch
     />
   );
 }

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -106,7 +106,7 @@ export function DecisionBodyFilter({
       value={decisionBodyIds}
       onSelect={onSelect}
       placeholder="Select decision body..."
-      scrollToTopOnSearch
+      resetScrollOnSearch
     />
   );
 }

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -63,7 +63,7 @@ export function SortDropdown() {
       placeholder="Sort by..."
       multiple={false}
       searchable={false}
-      reorderListItems={false}
+      reorderSelected={false}
     />
   );
 }
@@ -106,6 +106,7 @@ export function DecisionBodyFilter({
       value={decisionBodyIds}
       onSelect={onSelect}
       placeholder="Select decision body..."
+      scrollToTopOnSearch
     />
   );
 }

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -30,10 +30,8 @@ type Props<ID extends number | string> = {
   noResults?: string;
   /** Hides search bar if false */
   searchable?: boolean;
-  /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection */
-  reorderSelected?: boolean;
-  /** Scroll the dropdown list to the top when the search query changes - if we sort dropdown items on search then this is useful to keep the selected item in view */
-  scrollToTopOnSearch?: boolean;
+  /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection / search */
+  reorderListItems?: boolean;
   defaultValue?: ID | ID[];
 };
 
@@ -46,8 +44,7 @@ export const Combobox = <ID extends number | string>({
   placeholder,
   noResults,
   searchable = true,
-  reorderSelected = true,
-  scrollToTopOnSearch = false,
+  reorderListItems = true,
   defaultValue = undefined,
 }: Props<ID>) => {
   const [open, setOpen] = useState(false);
@@ -60,16 +57,16 @@ export const Combobox = <ID extends number | string>({
   }, []);
 
   useLayoutEffect(() => {
-    if (scrollToTopOnSearch) scrollListToTop();
-  }, [searchQuery, scrollToTopOnSearch, scrollListToTop]);
+    if (reorderListItems) scrollListToTop();
+  }, [searchQuery, reorderListItems, scrollListToTop]);
 
   const onSearchValueChange = useCallback(
     (value: string) => {
-      if (!scrollToTopOnSearch) return;
+      if (!reorderListItems) return;
       scrollListToTop();
       setSearchQuery(value);
     },
-    [scrollToTopOnSearch, scrollListToTop],
+    [reorderListItems, scrollListToTop],
   );
 
   const handleOpenChange = useCallback(
@@ -129,13 +126,13 @@ export const Combobox = <ID extends number | string>({
 
   const orderedOptions = useMemo(
     () =>
-      reorderSelected
+      reorderListItems
         ? [
             ...options.filter((opt) => isValueSelected(opt.id)),
             ...options.filter((opt) => !isValueSelected(opt.id)),
           ]
         : options,
-    [options, isValueSelected, reorderSelected],
+    [options, isValueSelected, reorderListItems],
   );
 
   return (
@@ -161,9 +158,7 @@ export const Combobox = <ID extends number | string>({
           {searchable && (
             <CommandInput
               placeholder={placeholder}
-              onValueChange={
-                scrollToTopOnSearch ? onSearchValueChange : undefined
-              }
+              onValueChange={reorderListItems ? onSearchValueChange : undefined}
             />
           )}
           <CommandList ref={commandListRef}>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -8,7 +8,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { cn } from '@/components/ui/utils';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Popover,
   PopoverContent,
@@ -32,6 +32,8 @@ type Props<ID extends number | string> = {
   searchable?: boolean;
   /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection */
   reorderSelected?: boolean;
+  /** Scroll the dropdown list to the top when the search query changes - if we sort dropdown items on search then this is useful to keep the selected item in view */
+  scrollToTopOnSearch?: boolean;
   defaultValue?: ID | ID[];
 };
 
@@ -45,9 +47,39 @@ export const Combobox = <ID extends number | string>({
   noResults,
   searchable = true,
   reorderSelected = true,
+  scrollToTopOnSearch = false,
   defaultValue = undefined,
 }: Props<ID>) => {
   const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const commandListRef = useRef<HTMLDivElement>(null);
+
+  const scrollListToTop = useCallback(() => {
+    const list = commandListRef.current;
+    if (list) list.scrollTop = 0;
+  }, []);
+
+  useLayoutEffect(() => {
+    if (scrollToTopOnSearch) scrollListToTop();
+  }, [searchQuery, scrollToTopOnSearch, scrollListToTop]);
+
+  const onSearchValueChange = useCallback(
+    (value: string) => {
+      if (!scrollToTopOnSearch) return;
+      scrollListToTop();
+      setSearchQuery(value);
+    },
+    [scrollToTopOnSearch, scrollListToTop],
+  );
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      setOpen(isOpen);
+      if (!isOpen) setSearchQuery('');
+    },
+    [setOpen, setSearchQuery],
+  );
+
   if (multiple && !Array.isArray(value)) {
     throw new Error(
       'Must pass list of strings for value if using multiple option on combobox.',
@@ -107,7 +139,7 @@ export const Combobox = <ID extends number | string>({
   );
 
   return (
-    <Popover open={open} onOpenChange={setOpen}>
+    <Popover open={open} onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <Button
           variant="outline"
@@ -126,8 +158,15 @@ export const Combobox = <ID extends number | string>({
       </PopoverTrigger>
       <PopoverContent className="max-w-[500px] p-0">
         <Command>
-          {searchable && <CommandInput placeholder={placeholder} />}
-          <CommandList>
+          {searchable && (
+            <CommandInput
+              placeholder={placeholder}
+              onValueChange={
+                scrollToTopOnSearch ? onSearchValueChange : undefined
+              }
+            />
+          )}
+          <CommandList ref={commandListRef}>
             {noResults && <CommandEmpty>{noResults}</CommandEmpty>}
             <CommandGroup>
               {orderedOptions.map((option) => (

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -32,7 +32,7 @@ type Props<ID extends number | string> = {
   searchable?: boolean;
   /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection */
   reorderSelected?: boolean;
-  /** Scroll the dropdown list to the top when the search query changes - if we sort dropdown items on search then this is useful to keep the selected item in view */
+  /** Scroll the dropdown list to the top when the search query changes - this is useful to keep the searched item in view */
   resetScrollOnSearch?: boolean;
   defaultValue?: ID | ID[];
 };

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -30,8 +30,10 @@ type Props<ID extends number | string> = {
   noResults?: string;
   /** Hides search bar if false */
   searchable?: boolean;
-  /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection / search */
-  reorderListItems?: boolean;
+  /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection */
+  reorderSelected?: boolean;
+  /** Scroll the dropdown list to the top when the search query changes - if we sort dropdown items on search then this is useful to keep the selected item in view */
+  scrollToTopOnSearch?: boolean;
   defaultValue?: ID | ID[];
 };
 
@@ -44,7 +46,8 @@ export const Combobox = <ID extends number | string>({
   placeholder,
   noResults,
   searchable = true,
-  reorderListItems = true,
+  reorderSelected = true,
+  scrollToTopOnSearch = false,
   defaultValue = undefined,
 }: Props<ID>) => {
   const [open, setOpen] = useState(false);
@@ -57,16 +60,16 @@ export const Combobox = <ID extends number | string>({
   }, []);
 
   useLayoutEffect(() => {
-    if (reorderListItems) scrollListToTop();
-  }, [searchQuery, reorderListItems, scrollListToTop]);
+    if (scrollToTopOnSearch) scrollListToTop();
+  }, [searchQuery, scrollToTopOnSearch, scrollListToTop]);
 
   const onSearchValueChange = useCallback(
     (value: string) => {
-      if (!reorderListItems) return;
+      if (!scrollToTopOnSearch) return;
       scrollListToTop();
       setSearchQuery(value);
     },
-    [reorderListItems, scrollListToTop],
+    [scrollToTopOnSearch, scrollListToTop],
   );
 
   const handleOpenChange = useCallback(
@@ -126,13 +129,13 @@ export const Combobox = <ID extends number | string>({
 
   const orderedOptions = useMemo(
     () =>
-      reorderListItems
+      reorderSelected
         ? [
             ...options.filter((opt) => isValueSelected(opt.id)),
             ...options.filter((opt) => !isValueSelected(opt.id)),
           ]
         : options,
-    [options, isValueSelected, reorderListItems],
+    [options, isValueSelected, reorderSelected],
   );
 
   return (
@@ -158,7 +161,9 @@ export const Combobox = <ID extends number | string>({
           {searchable && (
             <CommandInput
               placeholder={placeholder}
-              onValueChange={reorderListItems ? onSearchValueChange : undefined}
+              onValueChange={
+                scrollToTopOnSearch ? onSearchValueChange : undefined
+              }
             />
           )}
           <CommandList ref={commandListRef}>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -33,7 +33,7 @@ type Props<ID extends number | string> = {
   /** Keeps original order if false. Otherwise, reorders the items in the combo box based on selection */
   reorderSelected?: boolean;
   /** Scroll the dropdown list to the top when the search query changes - if we sort dropdown items on search then this is useful to keep the selected item in view */
-  scrollToTopOnSearch?: boolean;
+  resetScrollOnSearch?: boolean;
   defaultValue?: ID | ID[];
 };
 
@@ -47,7 +47,7 @@ export const Combobox = <ID extends number | string>({
   noResults,
   searchable = true,
   reorderSelected = true,
-  scrollToTopOnSearch = false,
+  resetScrollOnSearch = false,
   defaultValue = undefined,
 }: Props<ID>) => {
   const [open, setOpen] = useState(false);
@@ -60,16 +60,16 @@ export const Combobox = <ID extends number | string>({
   }, []);
 
   useLayoutEffect(() => {
-    if (scrollToTopOnSearch) scrollListToTop();
-  }, [searchQuery, scrollToTopOnSearch, scrollListToTop]);
+    if (resetScrollOnSearch) scrollListToTop();
+  }, [searchQuery, resetScrollOnSearch, scrollListToTop]);
 
   const onSearchValueChange = useCallback(
     (value: string) => {
-      if (!scrollToTopOnSearch) return;
+      if (!resetScrollOnSearch) return;
       scrollListToTop();
       setSearchQuery(value);
     },
-    [scrollToTopOnSearch, scrollListToTop],
+    [resetScrollOnSearch, scrollListToTop],
   );
 
   const handleOpenChange = useCallback(
@@ -162,7 +162,7 @@ export const Combobox = <ID extends number | string>({
             <CommandInput
               placeholder={placeholder}
               onValueChange={
-                scrollToTopOnSearch ? onSearchValueChange : undefined
+                resetScrollOnSearch ? onSearchValueChange : undefined
               }
             />
           )}


### PR DESCRIPTION
## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
Resolves #355

<!-- 2. Give a high-level description of what this PR does. -->
<!-- What was the behaviour before? What should it be now? -->

**Bug:** Scroll remained in an arbitrary position after dropdown is reordered on sort
**Expected:** Scroll to move to the top if dropdown supports reordering 

**BEFORE:**

https://github.com/user-attachments/assets/228ca517-230b-4d17-a7b5-45559f06a295


**AFTER:**

https://github.com/user-attachments/assets/8107ae95-221f-46a7-8da8-76a5befbda83

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->

1. Navigate to Action page
2. On the decision body filter Search "transit"
3. Scroll should remain at the top
4. On the Dropdown next to the Search bar make sure behaviour is not changed when you select "Newest" | "Oldest" | "Most relevant" 

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
