### PR TITLE
fix/382 - partial matching of action item code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8165,7 +8165,6 @@
       "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
@@ -8685,7 +8684,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8708,7 +8706,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10013,7 +10010,6 @@
       "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -13248,7 +13244,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -13260,7 +13255,6 @@
       "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -13335,7 +13329,6 @@
       "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",
@@ -13815,7 +13808,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14375,7 +14367,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -16188,7 +16179,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -16273,7 +16263,6 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -16372,7 +16361,6 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -18888,7 +18876,6 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.27.6.tgz",
       "integrity": "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -19027,7 +19014,6 @@
       "resolved": "https://registry.npmjs.org/kysely-postgres-js/-/kysely-postgres-js-2.0.0.tgz",
       "integrity": "sha512-R1tWx6/x3tSatWvsmbHJxpBZYhNNxcnMw52QzZaHKg7ZOWtHib4iZyEaw4gb2hNKVctWQ3jfMxZT/ZaEMK6kBQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "kysely": ">= 0.24.0 < 1",
         "postgres": ">= 3.4.0 < 4"
@@ -21036,7 +21022,6 @@
       "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.8.0",
@@ -21223,7 +21208,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -21332,7 +21316,6 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.5.tgz",
       "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==",
       "license": "Unlicense",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21400,7 +21383,6 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21594,7 +21576,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21607,7 +21588,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -24106,7 +24086,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -24686,7 +24665,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24767,7 +24745,6 @@
       "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.7",
@@ -25263,7 +25240,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -25284,7 +25260,6 @@
       "integrity": "sha512-ntm1OsIB2r/f7b5bfS84Lzz5QEx3zn4vUsn1JOVz/+7bw8triyytnxbp68OwOimF1vL5A9sQ0Nd+L6u8F3hECg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
         "@cloudflare/unenv-preset": "2.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8165,6 +8165,7 @@
       "integrity": "sha512-tVQRucExLQ02Boi4vdPp49svNGcfL2GhdTCT9aldhXgCJVAI21EtRfBettiuLUwce/7r6bFdgs6JFkcdTiFttA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
@@ -8684,6 +8685,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -8706,6 +8708,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -10010,6 +10013,7 @@
       "integrity": "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -13244,6 +13248,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
       "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -13255,6 +13260,7 @@
       "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -13329,6 +13335,7 @@
       "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.30.1",
         "@typescript-eslint/types": "8.30.1",
@@ -13808,6 +13815,7 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -14367,6 +14375,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -16179,6 +16188,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -16263,6 +16273,7 @@
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -16361,6 +16372,7 @@
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -18876,6 +18888,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.27.6.tgz",
       "integrity": "sha512-FIyV/64EkKhJmjgC0g2hygpBv5RNWVPyNCqSAD7eTCv6eFWNIi4PN1UvdSJGicN/o35bnevgis4Y0UDC0qi8jQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -19014,6 +19027,7 @@
       "resolved": "https://registry.npmjs.org/kysely-postgres-js/-/kysely-postgres-js-2.0.0.tgz",
       "integrity": "sha512-R1tWx6/x3tSatWvsmbHJxpBZYhNNxcnMw52QzZaHKg7ZOWtHib4iZyEaw4gb2hNKVctWQ3jfMxZT/ZaEMK6kBQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "kysely": ">= 0.24.0 < 1",
         "postgres": ">= 3.4.0 < 4"
@@ -21022,6 +21036,7 @@
       "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.7.0",
         "pg-pool": "^3.8.0",
@@ -21208,6 +21223,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -21316,6 +21332,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.5.tgz",
       "integrity": "sha512-cDWgoah1Gez9rN3H4165peY9qfpEo+SA61oQv65O3cRUE1pOEoJWwddwcqKE8XZYjbblOJlYDlLV4h67HrEVDg==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -21383,6 +21400,7 @@
       "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -21576,6 +21594,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -21588,6 +21607,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -24086,6 +24106,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -24665,6 +24686,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -24745,6 +24767,7 @@
       "integrity": "sha512-Wj7/AMtE9MRnAXa6Su3Lk0LNCfqDYgfwVjwRFVum9U7wsto1imuHqk4kTm7Jni+5A0Hn7dttL6O/zjvUvoo+8A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "defu": "^6.1.4",
         "exsolve": "^1.0.7",
@@ -25240,6 +25263,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "workerd": "bin/workerd"
       },
@@ -25260,6 +25284,7 @@
       "integrity": "sha512-ntm1OsIB2r/f7b5bfS84Lzz5QEx3zn4vUsn1JOVz/+7bw8triyytnxbp68OwOimF1vL5A9sQ0Nd+L6u8F3hECg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.0",
         "@cloudflare/unenv-preset": "2.7.3",

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -352,7 +352,16 @@ export const searchAgendaItems = async (
     pagination: { page, pageSize },
   }: SearchAgendaItemArgs,
 ) => {
-  const postgresQuery = queryAndTagsToPostgresTextSearchQuery({
+  // Generate separate queries for tags and text to filter independently
+  const tagsQuery = queryAndTagsToPostgresTextSearchQuery({
+    textQuery: '',
+    tags,
+  });
+  const textOnlyQuery = queryAndTagsToPostgresTextSearchQuery({
+    textQuery,
+    tags: [],
+  });
+  const combinedQuery = queryAndTagsToPostgresTextSearchQuery({
     textQuery,
     tags,
   });
@@ -367,13 +376,13 @@ export const searchAgendaItems = async (
         .orderBy('meetingDate', 'desc'),
     )
     .with('query', (db) =>
-      db.selectNoFrom(sql`to_tsquery('english', ${postgresQuery})`.as('query')),
+      db.selectNoFrom(sql`to_tsquery('english', ${combinedQuery})`.as('query')),
     )
     .with('filteredAgendaItems', (db) => {
       let query = db
         .selectFrom(['mostRecentConsiderations', 'query'])
         .select(agendaItemConflictColumns)
-        .$if(Boolean(postgresQuery), (query) =>
+        .$if(Boolean(combinedQuery), (query) =>
           query.select(sql`ts_rank("textSearchVector", query)`.as('rank')),
         );
 
@@ -387,10 +396,18 @@ export const searchAgendaItems = async (
         query = query.where('termId', '=', termId);
       }
 
-      if (postgresQuery) {
+      // Apply tag filtering as a mandatory condition
+      if (tagsQuery) {
+        query = query.where(
+          sql<boolean>`"textSearchVector" @@ to_tsquery('english', ${tagsQuery})`,
+        );
+      }
+
+      // Apply text filtering (can match in search vector or reference field)
+      if (textOnlyQuery) {
         query = query.where((eb) =>
           eb.or([
-            sql<boolean>`"textSearchVector" @@ query.query`,
+            sql<boolean>`"textSearchVector" @@ to_tsquery('english', ${textOnlyQuery})`,
             // Partial matching of text query to 'reference' column of action item
             eb('reference', 'ilike', `%${textQuery}%`),
           ]),
@@ -429,7 +446,7 @@ export const searchAgendaItems = async (
 
   query = query
     .orderBy(
-      sortBy === 'relevance' && Boolean(postgresQuery) ? 'rank' : 'meetingDate',
+      sortBy === 'relevance' && Boolean(combinedQuery) ? 'rank' : 'meetingDate',
       sortDirection === 'ascending' ? 'asc' : 'desc',
     )
     .limit(pageSize)

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -391,6 +391,7 @@ export const searchAgendaItems = async (
         query = query.where((eb) =>
           eb.or([
             sql<boolean>`"textSearchVector" @@ query.query`,
+            // Partial matching of text query to 'reference' column of action item
             eb('reference', 'ilike', `%${textQuery}%`),
           ]),
         );

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -388,7 +388,12 @@ export const searchAgendaItems = async (
       }
 
       if (postgresQuery) {
-        query = query.whereRef('textSearchVector', '@@', 'query');
+        query = query.where((eb) =>
+          eb.or([
+            sql<boolean>`"textSearchVector" @@ query.query`,
+            eb('reference', 'ilike', `%${textQuery}%`),
+          ]),
+        );
       }
 
       if (minimumDate !== undefined) {


### PR DESCRIPTION
## Description

<!-- 1. Link the related issue here. -->
<!-- Replace "Resolves" with "Related to" if this PR should not close the issue (e.g. if the issue requires several PRs to complete) -->
Resolves #382

<!-- 2. Give a high-level description of what this PR does. -->
Implements partial matching of text query with the reference field of action items.
<!-- What was the behaviour before? What should it be now? -->
Before, inputting substrings of action item codes would yield no results. Now, action items with codes that partially match the user's query are returned.

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->
Before:
<img width="1916" height="917" alt="image" src="https://github.com/user-attachments/assets/9f08a15a-caf2-453a-863c-82e29091b3f9" />

After:
<img width="1919" height="919" alt="image" src="https://github.com/user-attachments/assets/b22e9df3-3976-48e4-b308-a354ae8dcc72" />

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->
Go to the Actions page and search for parts of action item codes (e.g. "GG", "CA36"). You should see a list of action items with codes that partially match the search query.

Also, try searching for key terms and selecting tags to ensure that the new logic doesn't interfere with existing search functionality.

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
