### PR TITLE
Github actions: Update compose-action to v3.0.0

### DIFF
--- a/.github/workflows/check_migrations.yml
+++ b/.github/workflows/check_migrations.yml
@@ -26,7 +26,7 @@ jobs:
       # i'm not sure why `npm run db:start` doesn't work here,
       # but the remaining commands can't connect to the DB without using this action
       - name: Start database
-        uses: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a # v2.6.0
+        uses: hoverkraft-tech/compose-action@11beaa1c2dae4e8ed7b1665aa074723b6cecb0e4 # v3.0.0
 
       - name: Run migrations
         run: npm run db:run-migrations


### PR DESCRIPTION
Update compose-action to v3.0.0. in our Github actions (Support for Node.js 24)

This should fix this warning on the Github action `Check migrations` : Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: hoverkraft-tech/compose-action@d2bee4f07e8ca410d6b196d00f90c12e7d48c33a. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. 


## Description
Resolves https://github.com/civic-dashboard/civic-dashboard-web/issues/389

## Testing instructions
Go to Github Actions -> Check migrations -> select branch updateComposeActionNode --> Ensure the github action ran successfully and that it does not show the warning about using Node 20
https://github.com/civic-dashboard/civic-dashboard-web/actions/workflows/check_migrations.yml?query=branch%3AupdateComposeActionNode

## Checklist
- [X ] This PR addresses all requirements described in the issue
- [X ] I have commented my code, particularly in hard-to-understand areas
- [ X] I have performed a self-review of my code
- [ ] I have tested these changes in my local environment
- [X ] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
