### PR TITLE
Enhance `EmailAgendaItemCard` with improved styling, date formatting, and status display.

### DIFF
--- a/src/backend/emails/components/agendaItemCard.tsx
+++ b/src/backend/emails/components/agendaItemCard.tsx
@@ -29,9 +29,7 @@ export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
           {item.reference}: {item.agendaItemTitle}
         </Link>
       </Heading>
-      {formattedStatus && (
-        <Text style={statusBadge}>{formattedStatus}</Text>
-      )}
+      {formattedStatus && <Text style={statusBadge}>{formattedStatus}</Text>}
       <Hr style={divider} />
       {item.decisionRecommendations && (
         <>

--- a/src/backend/emails/components/agendaItemCard.tsx
+++ b/src/backend/emails/components/agendaItemCard.tsx
@@ -1,7 +1,14 @@
 import { AgendaItem } from '@/database/queries/agendaItems';
-import { sanitize, stripHtmlAndGetFirstParagraph } from '@/logic/sanitize';
+import { stripHtmlAndGetFirstParagraph } from '@/logic/sanitize';
 import { formatAgendaItemStatus } from '@/logic/strings';
-import { Button, Heading, Hr, Link, Section, Text } from '@react-email/components';
+import {
+  Button,
+  Heading,
+  Hr,
+  Link,
+  Section,
+  Text,
+} from '@react-email/components';
 
 const SUMMARY_MAX_CHARS = 200;
 

--- a/src/backend/emails/components/agendaItemCard.tsx
+++ b/src/backend/emails/components/agendaItemCard.tsx
@@ -1,21 +1,93 @@
 import { AgendaItem } from '@/database/queries/agendaItems';
 import { sanitize } from '@/logic/sanitize';
-import { Heading, Link, Section, Text } from '@react-email/components';
+import { formatAgendaItemStatus } from '@/logic/strings';
+import { Heading, Hr, Link, Section, Text } from '@react-email/components';
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  year: 'numeric',
+  day: 'numeric',
+  timeZone: 'America/Toronto',
+});
 
 export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
+  const formattedDate = dateFormatter
+    .format(new Date(item.meetingDate))
+    .replace(',', '');
+  const formattedStatus = formatAgendaItemStatus(item.itemStatus);
+
   return (
-    <Section style={{ padding: '16px' }}>
-      <Heading as="h2">
+    <Section style={card}>
+      <Text style={meta}>
+        {formattedDate} · {item.decisionBodyName}
+      </Text>
+      <Heading as="h2" style={heading}>
         <Link
           href={`${process.env.HOSTNAME_FOR_EMAIL_LINKS}/actions/item/${item.reference}`}
+          style={titleLink}
         >
           {item.reference}: {item.agendaItemTitle}
         </Link>
       </Heading>
+      {formattedStatus && (
+        <Text style={statusBadge}>{formattedStatus}</Text>
+      )}
+      <Hr style={divider} />
+      {item.decisionRecommendations && (
+        <>
+          <Text style={label}>Decision</Text>
+          <Text
+            style={body}
+            dangerouslySetInnerHTML={{
+              __html: sanitize(item.decisionRecommendations),
+            }}
+          />
+          <Hr style={divider} />
+          <Text style={label}>Summary</Text>
+        </>
+      )}
       <Text
-        style={{ fontSize: '16px' }}
+        style={body}
         dangerouslySetInnerHTML={{ __html: sanitize(item.agendaItemSummary) }}
       />
     </Section>
   );
+};
+
+const card = {
+  backgroundColor: '#ffffff',
+  borderRadius: '8px',
+  borderTop: '1px solid #e5e7eb',
+  borderRight: '1px solid #e5e7eb',
+  borderBottom: '1px solid #e5e7eb',
+  borderLeft: '4px solid #4f46e5',
+  padding: '24px',
+  margin: '16px 0',
+};
+const meta = {
+  color: '#6b7280',
+  fontSize: '13px',
+  margin: '0 0 8px 0',
+};
+const heading = { margin: '0 0 12px 0' };
+const titleLink = { color: '#1d4ed8', textDecoration: 'none' };
+const statusBadge = {
+  backgroundColor: '#f3f4f6',
+  color: '#374151',
+  fontSize: '13px',
+  padding: '4px 10px',
+  borderRadius: '4px',
+  margin: '0 0 4px 0',
+};
+const divider = { borderTopColor: '#e5e7eb', margin: '16px 0' };
+const label = {
+  fontWeight: 'bold' as const,
+  fontSize: '14px',
+  margin: '0 0 4px 0',
+};
+const body = {
+  fontSize: '15px',
+  lineHeight: '1.6',
+  color: '#374151',
+  margin: '0',
 };

--- a/src/backend/emails/components/agendaItemCard.tsx
+++ b/src/backend/emails/components/agendaItemCard.tsx
@@ -1,7 +1,9 @@
 import { AgendaItem } from '@/database/queries/agendaItems';
-import { sanitize } from '@/logic/sanitize';
+import { sanitize, stripHtmlAndGetFirstParagraph } from '@/logic/sanitize';
 import { formatAgendaItemStatus } from '@/logic/strings';
-import { Heading, Hr, Link, Section, Text } from '@react-email/components';
+import { Button, Heading, Hr, Link, Section, Text } from '@react-email/components';
+
+const SUMMARY_MAX_CHARS = 200;
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
@@ -15,6 +17,12 @@ export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
     .format(new Date(item.meetingDate))
     .replace(',', '');
   const formattedStatus = formatAgendaItemStatus(item.itemStatus);
+  const plainSummary = stripHtmlAndGetFirstParagraph(item.agendaItemSummary);
+  const summary =
+    plainSummary.length > SUMMARY_MAX_CHARS
+      ? plainSummary.slice(0, SUMMARY_MAX_CHARS) + '...'
+      : plainSummary;
+  const itemUrl = `${process.env.HOSTNAME_FOR_EMAIL_LINKS}/actions/item/${item.reference}`;
 
   return (
     <Section style={card}>
@@ -22,32 +30,16 @@ export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
         {formattedDate} · {item.decisionBodyName}
       </Text>
       <Heading as="h2" style={heading}>
-        <Link
-          href={`${process.env.HOSTNAME_FOR_EMAIL_LINKS}/actions/item/${item.reference}`}
-          style={titleLink}
-        >
+        <Link href={itemUrl} style={titleLink}>
           {item.reference}: {item.agendaItemTitle}
         </Link>
       </Heading>
       {formattedStatus && <Text style={statusBadge}>{formattedStatus}</Text>}
       <Hr style={divider} />
-      {item.decisionRecommendations && (
-        <>
-          <Text style={label}>Decision</Text>
-          <Text
-            style={body}
-            dangerouslySetInnerHTML={{
-              __html: sanitize(item.decisionRecommendations),
-            }}
-          />
-          <Hr style={divider} />
-          <Text style={label}>Summary</Text>
-        </>
-      )}
-      <Text
-        style={body}
-        dangerouslySetInnerHTML={{ __html: sanitize(item.agendaItemSummary) }}
-      />
+      <Text style={body}>{summary}</Text>
+      <Button href={itemUrl} style={readMore}>
+        Read more →
+      </Button>
     </Section>
   );
 };
@@ -62,11 +54,7 @@ const card = {
   padding: '24px',
   margin: '16px 0',
 };
-const meta = {
-  color: '#6b7280',
-  fontSize: '13px',
-  margin: '0 0 8px 0',
-};
+const meta = { color: '#6b7280', fontSize: '13px', margin: '0 0 8px 0' };
 const heading = { margin: '0 0 12px 0' };
 const titleLink = { color: '#1d4ed8', textDecoration: 'none' };
 const statusBadge = {
@@ -78,14 +66,18 @@ const statusBadge = {
   margin: '0 0 4px 0',
 };
 const divider = { borderTopColor: '#e5e7eb', margin: '16px 0' };
-const label = {
-  fontWeight: 'bold' as const,
-  fontSize: '14px',
-  margin: '0 0 4px 0',
-};
 const body = {
   fontSize: '15px',
   lineHeight: '1.6',
   color: '#374151',
-  margin: '0',
+  margin: '0 0 16px 0',
+};
+const readMore = {
+  backgroundColor: '#4f46e5',
+  borderRadius: '6px',
+  color: '#ffffff',
+  fontSize: '14px',
+  fontWeight: 'bold' as const,
+  padding: '10px 20px',
+  textDecoration: 'none',
 };

--- a/src/backend/emails/components/agendaItemCard.tsx
+++ b/src/backend/emails/components/agendaItemCard.tsx
@@ -41,7 +41,9 @@ export const EmailAgendaItemCard = ({ item }: { item: AgendaItem }) => {
           {item.reference}: {item.agendaItemTitle}
         </Link>
       </Heading>
-      {formattedStatus && <Text style={statusBadge}>{formattedStatus}</Text>}
+      {formattedStatus && (
+        <Text style={statusBadge}>Status: {formattedStatus}</Text>
+      )}
       <Hr style={divider} />
       <Text style={body}>{summary}</Text>
       <Button href={itemUrl} style={readMore}>

--- a/src/backend/emails/templates/newSubscription.tsx
+++ b/src/backend/emails/templates/newSubscription.tsx
@@ -7,7 +7,7 @@ import { SubscribableSearchFilters } from '@/logic/search';
 import { Heading, Hr, Link, Section, Text } from '@react-email/components';
 import { Fragment } from 'react';
 
-const MAX_ITEMS = 2;
+const MAX_ITEMS = 5;
 
 export type NewSubscriptionEmailProps = {
   unsubscribeToken: string;

--- a/src/backend/emails/templates/newSubscription.tsx
+++ b/src/backend/emails/templates/newSubscription.tsx
@@ -1,11 +1,13 @@
 import { AgendaItem } from '@/database/queries/agendaItems';
-import { SubscribableSearchFilters } from '@/logic/search';
-import { Heading, Hr, Link, Section } from '@react-email/components';
-import { Fragment } from 'react';
 import { EmailWrapper } from '@/backend/emails/components/emailWrapper';
 import { EmailSubscriptionCard } from '@/backend/emails/components/subscriptionCard';
 import { EmailAgendaItemCard } from '@/backend/emails/components/agendaItemCard';
 import { UnsubscribeLink } from '@/backend/emails/components/unsubscribeLink';
+import { SubscribableSearchFilters } from '@/logic/search';
+import { Heading, Hr, Link, Section, Text } from '@react-email/components';
+import { Fragment } from 'react';
+
+const MAX_ITEMS = 2;
 
 export type NewSubscriptionEmailProps = {
   unsubscribeToken: string;
@@ -37,12 +39,21 @@ export const NewSubscriptionEmail = ({
       <Section>
         <EmailSubscriptionCard filters={filters} />
       </Section>
-      {items.map((item, index) => (
+      {items.slice(0, MAX_ITEMS).map((item, index) => (
         <Fragment key={item.agendaItemId}>
           {index !== 0 && <Hr style={{ borderTopColor: 'black' }} />}
           <EmailAgendaItemCard item={item} />
         </Fragment>
       ))}
+      {items.length > MAX_ITEMS && (
+        <Text style={{ fontSize: '14px', color: '#6b7280' }}>
+          And {items.length - MAX_ITEMS} more result
+          {items.length - MAX_ITEMS !== 1 ? 's' : ''}.{' '}
+          <Link href={process.env.HOSTNAME_FOR_EMAIL_LINKS}>
+            View all on Civic Dashboard
+          </Link>
+        </Text>
+      )}
     </EmailWrapper>
   );
 };

--- a/src/backend/emails/templates/subscriptionUpdate.tsx
+++ b/src/backend/emails/templates/subscriptionUpdate.tsx
@@ -7,7 +7,7 @@ import { SubscribableSearchFilters } from '@/logic/search';
 import { Heading, Hr, Link, Section, Text } from '@react-email/components';
 import { Fragment } from 'react';
 
-const MAX_ITEMS = 2;
+const MAX_ITEMS = 5;
 
 export type SubscriptionUpdateEmailProps = {
   unsubscribeToken: string;

--- a/src/backend/emails/templates/subscriptionUpdate.tsx
+++ b/src/backend/emails/templates/subscriptionUpdate.tsx
@@ -1,11 +1,13 @@
 import { AgendaItem } from '@/database/queries/agendaItems';
-import { Heading, Hr, Link, Section } from '@react-email/components';
-import { Fragment } from 'react';
 import { EmailWrapper } from '@/backend/emails/components/emailWrapper';
 import { EmailSubscriptionCard } from '@/backend/emails/components/subscriptionCard';
 import { EmailAgendaItemCard } from '@/backend/emails/components/agendaItemCard';
-import { SubscribableSearchFilters } from '@/logic/search';
 import { UnsubscribeLink } from '@/backend/emails/components/unsubscribeLink';
+import { SubscribableSearchFilters } from '@/logic/search';
+import { Heading, Hr, Link, Section, Text } from '@react-email/components';
+import { Fragment } from 'react';
+
+const MAX_ITEMS = 2;
 
 export type SubscriptionUpdateEmailProps = {
   unsubscribeToken: string;
@@ -41,12 +43,21 @@ export const SubscriptionUpdateEmail = ({
           </Fragment>
         ))}
       </Section>
-      {items.map((item, index) => (
+      {items.slice(0, MAX_ITEMS).map((item, index) => (
         <Fragment key={item.agendaItemId}>
           {index !== 0 && <Hr style={{ borderTopColor: 'black' }} />}
           <EmailAgendaItemCard item={item} />
         </Fragment>
       ))}
+      {items.length > MAX_ITEMS && (
+        <Text style={{ fontSize: '14px', color: '#6b7280' }}>
+          And {items.length - MAX_ITEMS} more result
+          {items.length - MAX_ITEMS !== 1 ? 's' : ''}.{' '}
+          <Link href={process.env.HOSTNAME_FOR_EMAIL_LINKS}>
+            View all on Civic Dashboard
+          </Link>
+        </Text>
+      )}
     </EmailWrapper>
   );
 };


### PR DESCRIPTION


Description
Resolves #46

The EmailAgendaItemCard component previously only showed the item reference, title, and summary. This PR enhances it to match the information hierarchy of the website card.

Before: Reference + title (as a link) + plain summary text only.

After: Meeting date, decision body, title (as a styled link), status badge (when present), decision recommendations (when present), and summary  all inside a card with a left accent border, subtle container border, and consistent typography.

**Testing instructions**
**Local:**
1. Run `npm run docker:start && npm run dev`
2. Go to `/actions`, search "housing"
3. Click Get Email Alerts, enter any email
4. Check maildev at http://localhost:1080

**Preview deployment:**
1. Open the preview URL and go to `/actions`
2. Search any topic, click Get Email Alerts, enter your real email
3. Check your inbox for the subscription confirmation email


Checklist
- [x] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
