### PR TITLE
Improve agenda item search to support highlighting and sanitize output. Update components and types accordingly.

### DIFF
--- a/src/app/api/agenda-item/search/route.ts
+++ b/src/app/api/agenda-item/search/route.ts
@@ -1,7 +1,10 @@
 import { parseDateParam, parseNumberParam } from '@/api/utils';
 import { isTag } from '@/constants/tags';
 import { createDB } from '@/database/kyselyDb';
-import { AgendaItem, searchAgendaItems } from '@/database/queries/agendaItems';
+import {
+  AgendaItemSearchResult,
+  searchAgendaItems,
+} from '@/database/queries/agendaItems';
 import {
   SortByOption,
   sortByOptions,
@@ -14,7 +17,7 @@ export type AgendaItemSearchResponse = {
   page: number;
   pageSize: number;
   totalCount: number;
-  results: AgendaItem[];
+  results: AgendaItemSearchResult[];
 };
 
 export async function GET(request: NextRequest) {

--- a/src/app/labs/unified-search/AgendaItemCard.tsx
+++ b/src/app/labs/unified-search/AgendaItemCard.tsx
@@ -9,7 +9,11 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import type { AgendaItem } from '@/database/queries/agendaItems';
+import type {
+  AgendaItem,
+  AgendaItemSearchResult,
+} from '@/database/queries/agendaItems';
+import { sanitize } from '@/logic/sanitize';
 import { useSearch } from '@/contexts/SearchContext';
 import { Chip, ChipLink } from '@/components/ui/chip';
 import {
@@ -228,7 +232,7 @@ export function FullPageAgendaItemCard({
 }
 
 type SearchResultAgendaItemCardProps = {
-  item: AgendaItem;
+  item: AgendaItemSearchResult;
   decisionBody: DecisionBody;
 };
 export function SearchResultAgendaItemCard({
@@ -283,11 +287,22 @@ export function SearchResultAgendaItemCard({
           <div className="overflow-y-auto max-h-full">
             <HighlightChildren terms={textQuery}>
               <CardTitle>{item.agendaItemTitle}</CardTitle>
+            </HighlightChildren>
+            {item.searchHeadline ? (
+              <div
+                className="mt-2 [&_mark]:bg-yellow-200 dark:[&_mark]:bg-yellow-800 [&_mark]:rounded-sm"
+                dangerouslySetInnerHTML={{
+                  __html: sanitize(item.searchHeadline),
+                }}
+              />
+            ) : (
               <div
                 className="mt-2"
-                dangerouslySetInnerHTML={{ __html: item.agendaItemSummary }}
+                dangerouslySetInnerHTML={{
+                  __html: sanitize(item.agendaItemSummary),
+                }}
               />
-            </HighlightChildren>
+            )}
           </div>
         </div>
       </AgendaItemCard>

--- a/src/components/AgendaItemCard.tsx
+++ b/src/components/AgendaItemCard.tsx
@@ -9,7 +9,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import type { AgendaItem } from '@/database/queries/agendaItems';
+import type {
+  AgendaItem,
+  AgendaItemSearchResult,
+} from '@/database/queries/agendaItems';
 import { useSearch } from '@/contexts/SearchContext';
 import { Chip, ChipLink } from '@/components/ui/chip';
 import { Link2, MessageSquarePlus, Paperclip, Speech } from 'lucide-react';
@@ -329,7 +332,7 @@ const TakeActionDropdown = ({
 };
 
 type SearchResultAgendaItemCardProps = {
-  item: AgendaItem;
+  item: AgendaItemSearchResult;
   decisionBody: DecisionBody;
 };
 export function SearchResultAgendaItemCard({
@@ -379,13 +382,22 @@ export function SearchResultAgendaItemCard({
                   {formatAgendaItemStatus(item.itemStatus)}
                 </div>
               )}
+            </HighlightChildren>
+            {item.searchHeadline ? (
+              <div
+                className="mt-2 [&_mark]:bg-yellow-200 dark:[&_mark]:bg-yellow-800 [&_mark]:rounded-sm"
+                dangerouslySetInnerHTML={{
+                  __html: sanitize(item.searchHeadline),
+                }}
+              />
+            ) : (
               <div
                 className="mt-2"
                 dangerouslySetInnerHTML={{
                   __html: sanitize(item.agendaItemSummary),
                 }}
               />
-            </HighlightChildren>
+            )}
           </div>
         </div>
       </AgendaItemCard>

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -41,6 +41,10 @@ export interface AgendaItem {
   neighbourhoodId: number[] | null;
 }
 
+export type AgendaItemSearchResult = AgendaItem & {
+  searchHeadline: string | null;
+};
+
 type AgendaItemForSubjectTerm = Pick<
   AgendaItem,
   'agendaItemId' | 'subjectTerms'
@@ -440,9 +444,16 @@ export const searchAgendaItems = async (
       .executeTakeFirstOrThrow()
   ).count;
 
+  const headlineExpr = textOnlyQuery
+    ? sql<
+        string | null
+      >`ts_headline('english', regexp_replace("agendaItemSummary", '<[^>]+>', ' ', 'g'), to_tsquery('english', ${textOnlyQuery}), 'MaxWords=30, MinWords=15, StartSel=<mark>, StopSel=</mark>, HighlightAll=false')`
+    : sql<string | null>`NULL`;
+
   let query = commonTables
     .selectFrom('filteredAgendaItems')
-    .select(agendaItemConflictColumns);
+    .select(agendaItemConflictColumns)
+    .select(headlineExpr.as('searchHeadline'));
 
   query = query
     .orderBy(
@@ -454,7 +465,9 @@ export const searchAgendaItems = async (
 
   const rawResults = await query.execute();
 
-  const results: AgendaItem[] = rawResults.map(cleanAgendaItem);
+  const results = rawResults.map(
+    cleanAgendaItem,
+  ) as unknown as AgendaItemSearchResult[];
 
   return {
     totalCount,

--- a/src/database/queries/agendaItems.ts
+++ b/src/database/queries/agendaItems.ts
@@ -447,7 +447,7 @@ export const searchAgendaItems = async (
   const headlineExpr = textOnlyQuery
     ? sql<
         string | null
-      >`ts_headline('english', regexp_replace("agendaItemSummary", '<[^>]+>', ' ', 'g'), to_tsquery('english', ${textOnlyQuery}), 'MaxWords=30, MinWords=15, StartSel=<mark>, StopSel=</mark>, HighlightAll=false')`
+      >`ts_headline('english', regexp_replace("agendaItemSummary", '<[^>]+>', ' ', 'g'), to_tsquery('english', ${textOnlyQuery}), 'StartSel=<mark>, StopSel=</mark>, HighlightAll=true')`
     : sql<string | null>`NULL`;
 
   let query = commonTables

--- a/src/logic/sanitize.ts
+++ b/src/logic/sanitize.ts
@@ -19,6 +19,7 @@ const config: DOMPurifyConfig = {
     'td',
     'th',
     'tfoot',
+    'mark',
     // 'a', // Todo: tricky since we ought to add rel, target, and class
   ],
   ALLOWED_ATTR: ['title', 'style'],


### PR DESCRIPTION
## Description

Resolves #60

Search results previously used mark.js on the client to highlight matched terms with exact substring matching. This conflicted with the backend's Postgres full-text search, which uses English stemming so searching "housing" would find items containing "housed" or "houses" but mark.js would fail to highlight them, or would highlight unrelated substrings.

Before: Full HTML summary rendered in each card, client-side mark.js highlights exact substrings only. Stemmed matches (e.g. "dog" matching "dogs") were never highlighted.

After: Postgres ts_headline generates a short relevant excerpt server-side, with matched terms wrapped in <mark> tags that align exactly with what the full-text search engine matched. Tag-only searches (no text query) continue to show the full summary as before.

## Testing instructions

Local:
Run npm run docker:start && npm run dev
Go to /actions and type a search term like "park" or "zoning"
Confirm that stemmed variants are highlighted e.g. searching "parks" should highlight "parking" and "park" in the snippet
Click a tag without typing anything cards should show the full summary with no highlights
Preview deployment:

Open the preview URL and go to /actions
Search any topic and verify highlighted excerpts appear in the result cards
Confirm tag-only filtering still shows full summaries

** Confirm that stemmed variants are highlighted**

| before | after |
|-|-|
| <img width="1797" height="1281" alt="image" src="https://github.com/user-attachments/assets/97652ab2-bbd7-4f33-82ed-f917c42bc041" /> | <img width="1629" height="1282" alt="image" src="https://github.com/user-attachments/assets/bcca6f16-39cc-45a4-b119-6439ee774a54" /> |
| Full HTML summary rendered. Client-side mark.js highlights exact substrings only — stemmed matches are never highlighted. | Postgres `ts_headline` returns a short relevant excerpt with matched terms highlighted in yellow, aligned with what the search engine actually matched. |


## Checklist

- [x] This PR addresses all requirements described in the issue
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [ ] I have made corresponding changes to the documentation (if relevant)
