### PR TITLE
types: spruce up db type overrides

### DIFF
--- a/src/database/allDbTypes.d.ts
+++ b/src/database/allDbTypes.d.ts
@@ -47,10 +47,8 @@ export type InsertRawVote = Insertable<generated.RawVotes>;
  * See https://github.com/RobinBlomberg/kysely-codegen/issues/261
  */
 
-export interface Contacts extends Omit<
-  generated.Contacts,
-  'contactName' | 'contactSlug' | 'email'
-> {
+export interface Contacts
+  extends Omit<generated.Contacts, 'contactName' | 'contactSlug' | 'email'> {
   contactName: string;
   contactSlug: string;
   email: string;
@@ -60,10 +58,8 @@ declare const _assertContactsKeys: AssertExactKeys<
   Contacts
 >;
 
-export interface Councillors extends Omit<
-  generated.Councillors,
-  'contactSlug' | 'wardSlug' | 'term'
-> {
+export interface Councillors
+  extends Omit<generated.Councillors, 'contactSlug' | 'wardSlug' | 'term'> {
   contactSlug: string;
   wardSlug: string;
   term: string;
@@ -73,10 +69,8 @@ declare const _assertCouncillorsKeys: AssertExactKeys<
   Councillors
 >;
 
-export interface CouncilMembers extends Omit<
-  generated.CouncilMembers,
-  'contactSlug' | 'role' | 'term'
-> {
+export interface CouncilMembers
+  extends Omit<generated.CouncilMembers, 'contactSlug' | 'role' | 'term'> {
   contactSlug: string;
   role: string;
   term: string;
@@ -92,10 +86,8 @@ export interface Mayors extends Omit<generated.Mayors, 'contactSlug' | 'term'> {
 }
 declare const _assertMayorsKeys: AssertExactKeys<generated.Mayors, Mayors>;
 
-export interface AgendaItems extends Omit<
-  generated.AgendaItems,
-  'agendaItemNumber' | 'agendaItemTitle'
-> {
+export interface AgendaItems
+  extends Omit<generated.AgendaItems, 'agendaItemNumber' | 'agendaItemTitle'> {
   agendaItemNumber: string;
   agendaItemTitle: string;
 }
@@ -135,10 +127,8 @@ declare const _assertCommitteesKeys: AssertExactKeys<
   Committees
 >;
 
-export interface Wards extends Omit<
-  generated.Wards,
-  'wardId' | 'wardSlug' | 'wardName'
-> {
+export interface Wards
+  extends Omit<generated.Wards, 'wardId' | 'wardSlug' | 'wardName'> {
   wardId: string;
   wardSlug: string;
   wardName: string;

--- a/src/database/allDbTypes.d.ts
+++ b/src/database/allDbTypes.d.ts
@@ -2,89 +2,189 @@
 // eslint-disable-next-line no-restricted-imports
 import * as generated from '@/database/generatedDbTypes';
 
+// Note that some values from this export will be overridden by exports later in this file.
 // eslint-disable-next-line no-restricted-imports
 export * from '@/database/generatedDbTypes';
 
-// Currently keysely codegen does not support materialized views.
-// For now we define their type manually here
+// ── Helpers ──────────────────────────────────────────────────────────
 
-export type Councillor = {
-  contactSlug: string;
-  wardSlug: string;
-  term: string;
-};
+/**
+ * Asserts that types T and U have exactly the same keys.
+ *
+ * Resolves to `true` when keys match, or `never` when they diverge.
+ * A `never` result causes a compile error on the declaration line,
+ * alerting that a column was added/removed from the underlying database
+ * view/table without updating the override.
+ */
+type AssertExactKeys<T, U> = [keyof T] extends [keyof U]
+  ? [keyof U] extends [keyof T]
+    ? true
+    : never
+  : never;
 
-export type Contact = {
-  contactName: string;
-  contactSlug: string;
-  photoUrl: string | null;
-  email: string;
-  phone: string | null;
-};
-
-export type Ward = {
-  wardSlug: string;
-  wardName: string;
-  wardId: string;
-};
-
-export type Vote = {
-  agendaItemNumber: string;
-  motionId: string;
-  contactSlug: string;
-  value: string;
-};
-
-export type Committees = {
-  committeeSlug: string;
-  committeeName: string;
-};
-
-export type Motion = {
-  agendaItemNumber: string;
-  motionId: string;
-  motionType: string;
-  voteDescription: string;
-  dateTime: string;
-  committeeSlug: string;
-  result: string;
-  resultKind: string;
-  yesVotes: number;
-  noVotes: number;
-};
-
-export type AgendaItem = {
-  agendaItemNumber: string;
-  agendaItemTitle: string;
-  movedBy: string;
-  secondedBy: string[];
-};
-
-export type Mayor = {
-  contactSlug: string;
-  term: string;
-};
-
-export type CouncilMember = {
-  contactSlug: string;
-  term: string;
-  role: 'Mayor' | 'Councillor';
-  wardSlug: string | null;
-  wardName: string | null;
-  wardId: string | null;
-};
-
-export type DB = generated.DB & {
-  Councillors: Councillor;
-  Contacts: Contact;
-  Wards: Ward;
-  Votes: Vote;
-  Motions: Motion;
-  AgendaItems: AgendaItem;
-  Committees: Committees;
-  Mayors: Mayor;
-  CouncilMembers: CouncilMember;
-};
+// ── Insertable types ──────────────────────────────────────────────────
 
 export type InsertRawContact = Insertable<generated.RawContacts>;
 export type InsertRawVote = Insertable<generated.RawVotes>;
+
+// ── Views / Materialized Views (corrected nullability) ────────────────
+
+/**
+ * Schema overrides for views/materialized views.
+ *
+ * PostgreSQL's information_schema always marks view columns as nullable,
+ * even when the underlying source tables enforce NOT NULL. This file
+ * corrects the generated types to match the actual database constraints.
+ *
+ * Each overridden interface extends its generated counterpart (minus the
+ * fields being overridden) so nullable fields don't have to be repeated.
+ *
+ * Note: `Wards.wardSlug/wardName` and `Councillors.wardSlug` are asserted
+ * non-null because the ingest pipeline enforces `districtName` as a
+ * mandatory CSV field (see `rawContactCsvParser`), even though the raw
+ * columns are nullable.
+ *
+ * See https://github.com/RobinBlomberg/kysely-codegen/issues/261
+ */
+
+export interface Contacts extends Omit<
+  generated.Contacts,
+  'contactName' | 'contactSlug' | 'email'
+> {
+  contactName: string;
+  contactSlug: string;
+  email: string;
+}
+declare const _assertContactsKeys: AssertExactKeys<
+  generated.Contacts,
+  Contacts
+>;
+
+export interface Councillors extends Omit<
+  generated.Councillors,
+  'contactSlug' | 'wardSlug' | 'term'
+> {
+  contactSlug: string;
+  wardSlug: string;
+  term: string;
+}
+declare const _assertCouncillorsKeys: AssertExactKeys<
+  generated.Councillors,
+  Councillors
+>;
+
+export interface CouncilMembers extends Omit<
+  generated.CouncilMembers,
+  'contactSlug' | 'role' | 'term'
+> {
+  contactSlug: string;
+  role: string;
+  term: string;
+}
+declare const _assertCouncilMembersKeys: AssertExactKeys<
+  generated.CouncilMembers,
+  CouncilMembers
+>;
+
+export interface Mayors extends Omit<generated.Mayors, 'contactSlug' | 'term'> {
+  contactSlug: string;
+  term: string;
+}
+declare const _assertMayorsKeys: AssertExactKeys<generated.Mayors, Mayors>;
+
+export interface AgendaItems extends Omit<
+  generated.AgendaItems,
+  'agendaItemNumber' | 'agendaItemTitle'
+> {
+  agendaItemNumber: string;
+  agendaItemTitle: string;
+}
+declare const _assertAgendaItemsKeys: AssertExactKeys<
+  generated.AgendaItems,
+  AgendaItems
+>;
+
+export interface Motions {
+  agendaItemNumber: string;
+  committeeSlug: string;
+  dateTime: string;
+  motionId: string;
+  motionType: string;
+  noVotes: number;
+  result: string;
+  resultKind: string;
+  voteDescription: string;
+  yesVotes: number;
+}
+declare const _assertMotionsKeys: AssertExactKeys<generated.Motions, Motions>;
+
+export interface Votes {
+  agendaItemNumber: string;
+  contactSlug: string;
+  motionId: string;
+  value: string;
+}
+declare const _assertVotesKeys: AssertExactKeys<generated.Votes, Votes>;
+
+export interface Committees {
+  committeeName: string;
+  committeeSlug: string;
+}
+declare const _assertCommitteesKeys: AssertExactKeys<
+  generated.Committees,
+  Committees
+>;
+
+export interface Wards extends Omit<
+  generated.Wards,
+  'wardId' | 'wardSlug' | 'wardName'
+> {
+  wardId: string;
+  wardSlug: string;
+  wardName: string;
+}
+declare const _assertWardsKeys: AssertExactKeys<generated.Wards, Wards>;
+
+export interface Movers {
+  agendaItemNumber: string;
+  movedBy: string;
+}
+declare const _assertMoversKeys: AssertExactKeys<generated.Movers, Movers>;
+
+export interface Seconders {
+  agendaItemNumber: string;
+  unnest: string;
+}
+declare const _assertSecondersKeys: AssertExactKeys<
+  generated.Seconders,
+  Seconders
+>;
+
+// ── Corrected DB type ────────────────────────────────────────────────
+
+export type DB = Omit<
+  generated.DB,
+  | 'AgendaItems'
+  | 'Committees'
+  | 'Contacts'
+  | 'CouncilMembers'
+  | 'Councillors'
+  | 'Mayors'
+  | 'Motions'
+  | 'Movers'
+  | 'Seconders'
+  | 'Votes'
+  | 'Wards'
+> & {
+  AgendaItems: AgendaItems;
+  Committees: Committees;
+  Contacts: Contacts;
+  CouncilMembers: CouncilMembers;
+  Councillors: Councillors;
+  Mayors: Mayors;
+  Motions: Motions;
+  Movers: Movers;
+  Seconders: Seconders;
+  Votes: Votes;
+  Wards: Wards;
+};

--- a/src/database/allDbTypes.ts
+++ b/src/database/allDbTypes.ts
@@ -1,6 +1,7 @@
 // This is the one place allowed to import from generated types as here is were we re-export them
 // eslint-disable-next-line no-restricted-imports
 import * as generated from '@/database/generatedDbTypes';
+import { Insertable } from 'kysely';
 
 // Note that some values from this export will be overridden by exports later in this file.
 // eslint-disable-next-line no-restricted-imports
@@ -19,8 +20,8 @@ export * from '@/database/generatedDbTypes';
 type AssertExactKeys<T, U> = [keyof T] extends [keyof U]
   ? [keyof U] extends [keyof T]
     ? true
-    : never
-  : never;
+    : `Extra keys in override not in generated: ${Exclude<keyof U, keyof T> & string}`
+  : `Missing keys from generated not in override: ${Exclude<keyof T, keyof U> & string}`;
 
 // ── Insertable types ──────────────────────────────────────────────────
 
@@ -47,27 +48,32 @@ export type InsertRawVote = Insertable<generated.RawVotes>;
  * See https://github.com/RobinBlomberg/kysely-codegen/issues/261
  */
 
+export interface AgendaItems
+  extends Omit<generated.AgendaItems, 'agendaItemNumber' | 'agendaItemTitle'> {
+  agendaItemNumber: string;
+  agendaItemTitle: string;
+}
+const _assertAgendaItemsKeys: AssertExactKeys<
+  generated.AgendaItems,
+  AgendaItems
+> = true;
+
+export interface Committees {
+  committeeName: string;
+  committeeSlug: string;
+}
+declare const _assertCommitteesKeys: AssertExactKeys<
+  generated.Committees,
+  Committees
+>;
+
 export interface Contacts
   extends Omit<generated.Contacts, 'contactName' | 'contactSlug' | 'email'> {
   contactName: string;
   contactSlug: string;
   email: string;
 }
-declare const _assertContactsKeys: AssertExactKeys<
-  generated.Contacts,
-  Contacts
->;
-
-export interface Councillors
-  extends Omit<generated.Councillors, 'contactSlug' | 'wardSlug' | 'term'> {
-  contactSlug: string;
-  wardSlug: string;
-  term: string;
-}
-declare const _assertCouncillorsKeys: AssertExactKeys<
-  generated.Councillors,
-  Councillors
->;
+const _assertContactsKeys: AssertExactKeys<generated.Contacts, Contacts> = true;
 
 export interface CouncilMembers
   extends Omit<generated.CouncilMembers, 'contactSlug' | 'role' | 'term'> {
@@ -75,26 +81,27 @@ export interface CouncilMembers
   role: string;
   term: string;
 }
-declare const _assertCouncilMembersKeys: AssertExactKeys<
+const _assertCouncilMembersKeys: AssertExactKeys<
   generated.CouncilMembers,
   CouncilMembers
->;
+> = true;
+
+export interface Councillors
+  extends Omit<generated.Councillors, 'contactSlug' | 'wardSlug' | 'term'> {
+  contactSlug: string;
+  wardSlug: string;
+  term: string;
+}
+const _assertCouncillorsKeys: AssertExactKeys<
+  generated.Councillors,
+  Councillors
+> = true;
 
 export interface Mayors extends Omit<generated.Mayors, 'contactSlug' | 'term'> {
   contactSlug: string;
   term: string;
 }
-declare const _assertMayorsKeys: AssertExactKeys<generated.Mayors, Mayors>;
-
-export interface AgendaItems
-  extends Omit<generated.AgendaItems, 'agendaItemNumber' | 'agendaItemTitle'> {
-  agendaItemNumber: string;
-  agendaItemTitle: string;
-}
-declare const _assertAgendaItemsKeys: AssertExactKeys<
-  generated.AgendaItems,
-  AgendaItems
->;
+const _assertMayorsKeys: AssertExactKeys<generated.Mayors, Mayors> = true;
 
 export interface Motions {
   agendaItemNumber: string;
@@ -108,7 +115,20 @@ export interface Motions {
   voteDescription: string;
   yesVotes: number;
 }
-declare const _assertMotionsKeys: AssertExactKeys<generated.Motions, Motions>;
+const _assertMotionsKeys: AssertExactKeys<generated.Motions, Motions> = true;
+
+export interface Movers {
+  agendaItemNumber: string;
+  movedBy: string;
+}
+const _assertMoversKeys: AssertExactKeys<generated.Movers, Movers> = true;
+
+export interface Seconders {
+  agendaItemNumber: string;
+  unnest: string;
+}
+const _assertSecondersKeys: AssertExactKeys<generated.Seconders, Seconders> =
+  true;
 
 export interface Votes {
   agendaItemNumber: string;
@@ -116,16 +136,7 @@ export interface Votes {
   motionId: string;
   value: string;
 }
-declare const _assertVotesKeys: AssertExactKeys<generated.Votes, Votes>;
-
-export interface Committees {
-  committeeName: string;
-  committeeSlug: string;
-}
-declare const _assertCommitteesKeys: AssertExactKeys<
-  generated.Committees,
-  Committees
->;
+const _assertVotesKeys: AssertExactKeys<generated.Votes, Votes> = true;
 
 export interface Wards
   extends Omit<generated.Wards, 'wardId' | 'wardSlug' | 'wardName'> {
@@ -133,22 +144,7 @@ export interface Wards
   wardSlug: string;
   wardName: string;
 }
-declare const _assertWardsKeys: AssertExactKeys<generated.Wards, Wards>;
-
-export interface Movers {
-  agendaItemNumber: string;
-  movedBy: string;
-}
-declare const _assertMoversKeys: AssertExactKeys<generated.Movers, Movers>;
-
-export interface Seconders {
-  agendaItemNumber: string;
-  unnest: string;
-}
-declare const _assertSecondersKeys: AssertExactKeys<
-  generated.Seconders,
-  Seconders
->;
+const _assertWardsKeys: AssertExactKeys<generated.Wards, Wards> = true;
 
 // ── Corrected DB type ────────────────────────────────────────────────
 

--- a/src/database/pipelines/rawContactCsvParser.ts
+++ b/src/database/pipelines/rawContactCsvParser.ts
@@ -67,7 +67,10 @@ export const formatContactCsvStream = (
 };
 
 // Process rows and validates fields
-async function processRow(row: CsvContactRow, term: string): InsertRawContact {
+async function processRow(
+  row: CsvContactRow,
+  term: string,
+): Promise<InsertRawContact> {
   if (!verifyFieldsAreNotNullish(MandatoryContactFields, row)) {
     throw new Error(`Missing not-nullable field(s)`, { cause: { row } });
   }


### PR DESCRIPTION
## Description
Sprinkles some type magic on the DB types:
- rather than redeclaring the full table shape for matviews, only declare the fields that we're actually narrowing to non-nullable
- add a type guard to ensure that the overrides contain the exact same fields as the underlying generated type

Other changes:
- Fix existing type issue in `rawContactsCsvParser.ts`

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->

1. Run `npx tsc --noEmit`, should show no errors
2. Modify a field in `src/database/generatedDbTypes.d.ts` that is in `src/database/allDbTypes.ts`
3. Run `npx tsc --noEmit`, should show an error

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
