### PR TITLE
Add weekly Umami Slack post

### DIFF
--- a/.github/workflows/post_analytics_summary.yml
+++ b/.github/workflows/post_analytics_summary.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 13 * * 1'  # Monday 9am ET (13:00 UTC)
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   SLACK_WEBHOOK_URL: <TODO>
 
@@ -19,5 +22,4 @@ jobs:
       - run: npm ci
       - run: npm run tsx src/scripts/postSlackAnalyticsSummary.ts
         env:
-          UMAMI_API_KEY: ${{ secrets.UMAMI_API_KEY }}
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/post_analytics_summary.yml
+++ b/.github/workflows/post_analytics_summary.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: read
 
-env:
-  SLACK_WEBHOOK_URL: <TODO>
-
 jobs:
   report:
     runs-on: ubuntu-latest
@@ -22,4 +19,4 @@ jobs:
       - run: npm ci
       - run: npm run tsx src/scripts/postSlackAnalyticsSummary.ts
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_ANALYTICS }}

--- a/.github/workflows/post_analytics_summary.yml
+++ b/.github/workflows/post_analytics_summary.yml
@@ -1,0 +1,23 @@
+name: Post analytics summary
+on:
+  schedule:
+    - cron: '0 13 * * 1'  # Monday 9am ET (13:00 UTC)
+  workflow_dispatch:
+
+env:
+  SLACK_WEBHOOK_URL: <TODO>
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.tool-versions'
+          cache: npm
+      - run: npm ci
+      - run: npm run tsx src/scripts/postSlackAnalyticsSummary.ts
+        env:
+          UMAMI_API_KEY: ${{ secrets.UMAMI_API_KEY }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/src/scripts/postSlackAnalyticsSummary.ts
+++ b/src/scripts/postSlackAnalyticsSummary.ts
@@ -1,0 +1,252 @@
+// Weekly analytics summary from Umami Cloud API to Slack.
+//
+// Fetches summary stats (with week-over-week comparison), top pages, and top
+// referrers for the last 7 days, formats a Slack message, and posts it to a
+// Slack incoming webhook.
+//
+// Usage:
+//   npm run tsxe src/scripts/postSlackAnalyticsSummary.ts              # live run
+//   npm run tsxe src/scripts/postSlackAnalyticsSummary.ts -- --dry-run # print only, no Slack post
+//
+// Env vars:
+//   UMAMI_API_KEY     — Bearer token (Umami dashboard → Settings → API Keys)
+//   SLACK_WEBHOOK_URL — Slack incoming webhook URL (required unless --dry-run)
+
+import { parseArgs } from 'node:util';
+
+// --- Config ---
+const WEBSITE_ID = 'cc44ac27-34a8-4561-8a0f-c0b448b090cd';
+const UMAMI_API_BASE = 'https://cloud.umami.is/api';
+
+// --- Types ---
+type StatField = {
+  value: number;
+  change: number;
+  prev: number;
+};
+
+type StatsResponse = {
+  pageviews: StatField;
+  visitors: StatField;
+  visits: StatField;
+  bounces: StatField;
+  totaltime: StatField;
+};
+
+type MetricEntry = {
+  x: string;
+  y: number;
+};
+
+// --- Pure functions (no I/O — testable) ---
+
+/** Formats a count with thousands separators: 1204 → "1,204" */
+function formatNumber(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+/** Formats a week-over-week delta as a signed percentage: 15 → "+15%", -12 → "-12%" */
+function formatPercent(change: number, prev: number): string {
+  if (prev === 0) return '—';
+  const pct = Math.round((change / prev) * 100);
+  const sign = pct >= 0 ? '+' : '';
+  return `${sign}${pct}%`;
+}
+
+/** Formats total seconds as a human duration: 153 → "2m 33s" */
+function formatDuration(totalSeconds: number): string {
+  const m = Math.floor(totalSeconds / 60);
+  const s = Math.round(totalSeconds % 60);
+  return `${m}m ${s}s`;
+}
+
+/** Formats a date range as "Aug 21–28" */
+function formatDateRange(start: Date, end: Date): string {
+  const month = start.toLocaleString('en-US', { month: 'short' });
+  return `${month} ${start.getDate()}–${end.getDate()}`;
+}
+
+/** Builds the Slack message text from stats and metrics */
+function buildSlackMessage(
+  stats: StatsResponse,
+  topPages: MetricEntry[],
+  topReferrers: MetricEntry[],
+  weekStart: Date,
+  now: Date,
+): string {
+  const bounceRate =
+    stats.visits.value > 0
+      ? (stats.bounces.value / stats.visits.value) * 100
+      : 0;
+  const prevBounceRate =
+    stats.visits.prev > 0 ? (stats.bounces.prev / stats.visits.prev) * 100 : 0;
+  const bounceRateChange = bounceRate - prevBounceRate;
+
+  const avgVisitTime =
+    stats.visits.value > 0 ? stats.totaltime.value / stats.visits.value : 0;
+  const prevAvgVisitTime =
+    stats.visits.prev > 0 ? stats.totaltime.prev / stats.visits.prev : 0;
+  const avgVisitTimeChange = avgVisitTime - prevAvgVisitTime;
+
+  const lines: string[] = [];
+  lines.push(
+    `📊 Weekly Analytics Summary — ${formatDateRange(weekStart, now)}`,
+  );
+  lines.push('');
+  lines.push(
+    `Pageviews: ${formatNumber(stats.pageviews.value)} (${formatPercent(stats.pageviews.change, stats.pageviews.prev)} vs last week)`,
+  );
+  lines.push(
+    `Unique visitors: ${formatNumber(stats.visitors.value)} (${formatPercent(stats.visitors.change, stats.visitors.prev)})`,
+  );
+  lines.push(
+    `Sessions: ${formatNumber(stats.visits.value)} (${formatPercent(stats.visits.change, stats.visits.prev)})`,
+  );
+  lines.push(
+    `Bounce rate: ${bounceRate.toFixed(1)}% (${bounceRateChange >= 0 ? '+' : ''}${bounceRateChange.toFixed(1)}%)`,
+  );
+  lines.push(
+    `Avg visit time: ${formatDuration(avgVisitTime)} (${avgVisitTimeChange >= 0 ? '+' : ''}${formatDuration(Math.abs(avgVisitTimeChange))})`,
+  );
+  lines.push('');
+
+  if (topPages.length > 0) {
+    lines.push('🔥 Top pages');
+    topPages.forEach((page, i) => {
+      lines.push(`  ${i + 1}. ${page.x} — ${formatNumber(page.y)} views`);
+    });
+    lines.push('');
+  }
+
+  if (topReferrers.length > 0) {
+    lines.push('🔗 Top referrers');
+    topReferrers.forEach((ref, i) => {
+      const label = ref.x || '(direct)';
+      lines.push(`  ${i + 1}. ${label} — ${formatNumber(ref.y)}`);
+    });
+  }
+
+  return lines.join('\n');
+}
+
+// --- I/O functions ---
+
+async function fetchStats(
+  apiBase: string,
+  websiteId: string,
+  apiKey: string,
+  startAt: number,
+  endAt: number,
+): Promise<StatsResponse> {
+  const url = `${apiBase}/websites/${websiteId}/stats?startAt=${startAt}&endAt=${endAt}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(`Stats request failed: ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as StatsResponse;
+}
+
+async function fetchMetrics(
+  apiBase: string,
+  websiteId: string,
+  apiKey: string,
+  startAt: number,
+  endAt: number,
+  type: 'url' | 'referrer',
+  limit: number,
+): Promise<MetricEntry[]> {
+  const url = `${apiBase}/websites/${websiteId}/metrics?startAt=${startAt}&endAt=${endAt}&type=${type}&limit=${limit}`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `Metrics (${type}) request failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return (await res.json()) as MetricEntry[];
+}
+
+async function postToSlack(webhookUrl: string, text: string): Promise<void> {
+  const res = await fetch(webhookUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  if (!res.ok) {
+    throw new Error(`Slack POST failed: ${res.status} ${res.statusText}`);
+  }
+}
+
+// --- Main ---
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({
+    options: {
+      'dry-run': { type: 'boolean', default: false },
+    },
+  });
+  const dryRun = values['dry-run'];
+
+  const apiKey = process.env.UMAMI_API_KEY;
+  if (!apiKey) {
+    throw new Error('UMAMI_API_KEY env var is required');
+  }
+
+  const webhookUrl = process.env.SLACK_WEBHOOK_URL;
+  if (!webhookUrl && !dryRun) {
+    throw new Error(
+      'SLACK_WEBHOOK_URL env var is required (use --dry-run to skip posting)',
+    );
+  }
+
+  // Time window: last 7 days from now, truncated to midnight UTC
+  const now = new Date();
+  const weekStart = new Date(now);
+  weekStart.setDate(now.getDate() - 7);
+  weekStart.setHours(0, 0, 0, 0);
+
+  const startAt = weekStart.getTime();
+  const endAt = now.getTime();
+
+  console.log(`Fetching analytics for ${formatDateRange(weekStart, now)}...`);
+
+  const [stats, topPages, topReferrers] = await Promise.all([
+    fetchStats(UMAMI_API_BASE, WEBSITE_ID, apiKey, startAt, endAt),
+    fetchMetrics(UMAMI_API_BASE, WEBSITE_ID, apiKey, startAt, endAt, 'url', 5),
+    fetchMetrics(
+      UMAMI_API_BASE,
+      WEBSITE_ID,
+      apiKey,
+      startAt,
+      endAt,
+      'referrer',
+      5,
+    ),
+  ]);
+
+  const message = buildSlackMessage(
+    stats,
+    topPages,
+    topReferrers,
+    weekStart,
+    now,
+  );
+
+  if (dryRun) {
+    console.log('\n--- Slack message (dry-run) ---\n');
+    console.log(message);
+    console.log('\n--- end ---');
+    return;
+  }
+
+  await postToSlack(webhookUrl!, message);
+  console.log('Posted weekly analytics summary to Slack.');
+}
+
+main().catch((err) => {
+  console.error('Error executing script:', err);
+  process.exit(1);
+});

--- a/src/scripts/postSlackAnalyticsSummary.ts
+++ b/src/scripts/postSlackAnalyticsSummary.ts
@@ -1,36 +1,47 @@
-// Weekly analytics summary from Umami Cloud API to Slack.
+// Weekly analytics summary from Umami Cloud to Slack.
 //
-// Fetches summary stats (with week-over-week comparison), top pages, and top
-// referrers for the last 7 days, formats a Slack message, and posts it to a
-// Slack incoming webhook.
+// Uses Umami's public share URL feature to authenticate (no API key needed,
+// works on the free Hobby tier). Fetches summary stats (with week-over-week
+// comparison), top pages, and top referrers for the last 7 days, formats a
+// Slack message, and posts it to a Slack incoming webhook.
 //
 // Usage:
 //   npm run tsxe src/scripts/postSlackAnalyticsSummary.ts              # live run
 //   npm run tsxe src/scripts/postSlackAnalyticsSummary.ts -- --dry-run # print only, no Slack post
 //
 // Env vars:
-//   UMAMI_API_KEY     — Bearer token (Umami dashboard → Settings → API Keys)
 //   SLACK_WEBHOOK_URL — Slack incoming webhook URL (required unless --dry-run)
 
 import { parseArgs } from 'node:util';
 
 // --- Config ---
-const WEBSITE_ID = 'cc44ac27-34a8-4561-8a0f-c0b448b090cd';
-const UMAMI_API_BASE = 'https://cloud.umami.is/api';
+
+const UMAMI_SHARE_SLUG = '6R9CNotgCUNEmDL5'; // Slug from public URL
+const UMAMI_API_BASE = 'https://cloud.umami.is/analytics/eu/api';
 
 // --- Types ---
-type StatField = {
-  value: number;
-  change: number;
-  prev: number;
+
+type ShareTokenResponse = {
+  shareId: string;
+  shareType: number;
+  parameters: Record<string, unknown>;
+  websiteId: string;
+  token: string;
 };
 
 type StatsResponse = {
-  pageviews: StatField;
-  visitors: StatField;
-  visits: StatField;
-  bounces: StatField;
-  totaltime: StatField;
+  pageviews: number;
+  visitors: number;
+  visits: number;
+  bounces: number;
+  totaltime: number;
+  comparison: {
+    pageviews: number;
+    visitors: number;
+    visits: number;
+    bounces: number;
+    totaltime: number;
+  };
 };
 
 type MetricEntry = {
@@ -46,9 +57,9 @@ function formatNumber(n: number): string {
 }
 
 /** Formats a week-over-week delta as a signed percentage: 15 → "+15%", -12 → "-12%" */
-function formatPercent(change: number, prev: number): string {
+function formatPercent(current: number, prev: number): string {
   if (prev === 0) return '—';
-  const pct = Math.round((change / prev) * 100);
+  const pct = Math.round(((current - prev) / prev) * 100);
   const sign = pct >= 0 ? '+' : '';
   return `${sign}${pct}%`;
 }
@@ -74,18 +85,15 @@ function buildSlackMessage(
   weekStart: Date,
   now: Date,
 ): string {
+  const prev = stats.comparison;
   const bounceRate =
-    stats.visits.value > 0
-      ? (stats.bounces.value / stats.visits.value) * 100
-      : 0;
+    stats.visits > 0 ? (stats.bounces / stats.visits) * 100 : 0;
   const prevBounceRate =
-    stats.visits.prev > 0 ? (stats.bounces.prev / stats.visits.prev) * 100 : 0;
+    prev.visits > 0 ? (prev.bounces / prev.visits) * 100 : 0;
   const bounceRateChange = bounceRate - prevBounceRate;
 
-  const avgVisitTime =
-    stats.visits.value > 0 ? stats.totaltime.value / stats.visits.value : 0;
-  const prevAvgVisitTime =
-    stats.visits.prev > 0 ? stats.totaltime.prev / stats.visits.prev : 0;
+  const avgVisitTime = stats.visits > 0 ? stats.totaltime / stats.visits : 0;
+  const prevAvgVisitTime = prev.visits > 0 ? prev.totaltime / prev.visits : 0;
   const avgVisitTimeChange = avgVisitTime - prevAvgVisitTime;
 
   const lines: string[] = [];
@@ -94,13 +102,13 @@ function buildSlackMessage(
   );
   lines.push('');
   lines.push(
-    `Pageviews: ${formatNumber(stats.pageviews.value)} (${formatPercent(stats.pageviews.change, stats.pageviews.prev)} vs last week)`,
+    `Pageviews: ${formatNumber(stats.pageviews)} (${formatPercent(stats.pageviews, prev.pageviews)} vs last week)`,
   );
   lines.push(
-    `Unique visitors: ${formatNumber(stats.visitors.value)} (${formatPercent(stats.visitors.change, stats.visitors.prev)})`,
+    `Unique visitors: ${formatNumber(stats.visitors)} (${formatPercent(stats.visitors, prev.visitors)})`,
   );
   lines.push(
-    `Sessions: ${formatNumber(stats.visits.value)} (${formatPercent(stats.visits.change, stats.visits.prev)})`,
+    `Sessions: ${formatNumber(stats.visits)} (${formatPercent(stats.visits, prev.visits)})`,
   );
   lines.push(
     `Bounce rate: ${bounceRate.toFixed(1)}% (${bounceRateChange >= 0 ? '+' : ''}${bounceRateChange.toFixed(1)}%)`,
@@ -131,16 +139,34 @@ function buildSlackMessage(
 
 // --- I/O functions ---
 
+/** Fetches a share token from the public share URL slug */
+async function fetchShareToken(
+  apiBase: string,
+  shareSlug: string,
+): Promise<ShareTokenResponse> {
+  const url = `${apiBase}/share/${shareSlug}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(
+      `Share token request failed: ${res.status} ${res.statusText}`,
+    );
+  }
+  return (await res.json()) as ShareTokenResponse;
+}
+
 async function fetchStats(
   apiBase: string,
   websiteId: string,
-  apiKey: string,
+  shareToken: string,
   startAt: number,
   endAt: number,
 ): Promise<StatsResponse> {
   const url = `${apiBase}/websites/${websiteId}/stats?startAt=${startAt}&endAt=${endAt}`;
   const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${apiKey}` },
+    headers: {
+      'x-umami-share-token': shareToken,
+      'x-umami-share-context': '1',
+    },
   });
   if (!res.ok) {
     throw new Error(`Stats request failed: ${res.status} ${res.statusText}`);
@@ -151,15 +177,18 @@ async function fetchStats(
 async function fetchMetrics(
   apiBase: string,
   websiteId: string,
-  apiKey: string,
+  shareToken: string,
   startAt: number,
   endAt: number,
-  type: 'url' | 'referrer',
+  type: 'path' | 'referrer',
   limit: number,
 ): Promise<MetricEntry[]> {
   const url = `${apiBase}/websites/${websiteId}/metrics?startAt=${startAt}&endAt=${endAt}&type=${type}&limit=${limit}`;
   const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${apiKey}` },
+    headers: {
+      'x-umami-share-token': shareToken,
+      'x-umami-share-context': '1',
+    },
   });
   if (!res.ok) {
     throw new Error(
@@ -190,11 +219,6 @@ async function main(): Promise<void> {
   });
   const dryRun = values['dry-run'];
 
-  const apiKey = process.env.UMAMI_API_KEY;
-  if (!apiKey) {
-    throw new Error('UMAMI_API_KEY env var is required');
-  }
-
   const webhookUrl = process.env.SLACK_WEBHOOK_URL;
   if (!webhookUrl && !dryRun) {
     throw new Error(
@@ -213,13 +237,28 @@ async function main(): Promise<void> {
 
   console.log(`Fetching analytics for ${formatDateRange(weekStart, now)}...`);
 
+  // Step 1: get share token (provides auth for all subsequent calls)
+  const { token: shareToken, websiteId } = await fetchShareToken(
+    UMAMI_API_BASE,
+    UMAMI_SHARE_SLUG,
+  );
+
+  // Step 2: fetch stats + metrics in parallel
   const [stats, topPages, topReferrers] = await Promise.all([
-    fetchStats(UMAMI_API_BASE, WEBSITE_ID, apiKey, startAt, endAt),
-    fetchMetrics(UMAMI_API_BASE, WEBSITE_ID, apiKey, startAt, endAt, 'url', 5),
+    fetchStats(UMAMI_API_BASE, websiteId, shareToken, startAt, endAt),
     fetchMetrics(
       UMAMI_API_BASE,
-      WEBSITE_ID,
-      apiKey,
+      websiteId,
+      shareToken,
+      startAt,
+      endAt,
+      'path',
+      5,
+    ),
+    fetchMetrics(
+      UMAMI_API_BASE,
+      websiteId,
+      shareToken,
       startAt,
       endAt,
       'referrer',

--- a/src/scripts/postSlackAnalyticsSummary.ts
+++ b/src/scripts/postSlackAnalyticsSummary.ts
@@ -3,14 +3,14 @@
 // Uses Umami's public share URL feature to authenticate (no API key needed,
 // works on the free Hobby tier). Fetches summary stats (with week-over-week
 // comparison), top pages, and top referrers for the last 7 days, formats a
-// Slack message, and posts it to a Slack incoming webhook.
+// Slack message, and posts it to a Slack workflow webhook trigger.
 //
 // Usage:
-//   npm run tsxe src/scripts/postSlackAnalyticsSummary.ts              # live run
-//   npm run tsxe src/scripts/postSlackAnalyticsSummary.ts -- --dry-run # print only, no Slack post
+//   npm run tsx src/scripts/postSlackAnalyticsSummary.ts              # live run
+//   npm run tsx src/scripts/postSlackAnalyticsSummary.ts -- --dry-run # print only, no Slack post
 //
 // Env vars:
-//   SLACK_WEBHOOK_URL — Slack incoming webhook URL (required unless --dry-run)
+//   SLACK_WEBHOOK_URL — Slack workflow webhook trigger URL (required unless --dry-run)
 
 import { parseArgs } from 'node:util';
 
@@ -198,11 +198,11 @@ async function fetchMetrics(
   return (await res.json()) as MetricEntry[];
 }
 
-async function postToSlack(webhookUrl: string, text: string): Promise<void> {
+async function postToSlack(webhookUrl: string, message: string): Promise<void> {
   const res = await fetch(webhookUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ text }),
+    body: JSON.stringify({ message }),
   });
   if (!res.ok) {
     throw new Error(`Slack POST failed: ${res.status} ${res.statusText}`);


### PR DESCRIPTION
## Description

Resolves #508 

Implements a script to fetch analytics and post a summary to Slack. Includes a GHA workflow to run weekly, or manually for testing.

<!-- 3. If this PR results in something changing visually on the site, include before/after screenshots. -->

This is an example of the Slack message:
```
📊 Weekly Analytics Summary — Aug 24–31

Pageviews: 614 (-45% vs last week)
Unique visitors: 322 (-14%)
Sessions: 371 (-16%)
Bounce rate: 76.0% (+12.7%)
Avg visit time: 1m 22s (0m 42s)

🔥 Top pages
  1. / — 86 views
  2. /councillors — 55 views
  3. /actions — 24 views
  4. /how-council-works — 17 views
  5. /councillors/alejandra-bravo — 14 views

🔗 Top referrers
  1. google.com — 126
  2. htmlpreview.github.io — 6
  3. bing.com — 5
  4. civictech.ca — 5
  5. google.ca — 3

```

<!-- 4. If you have specific code review directions, include them here. -->
<!-- E.g. "Look at these files first" or "Review one commit at a time" -->

## Testing instructions

<!-- Describe how the reviewer should test this change. -->
<!-- E.g. Which page should they look at? What should they click? What should happen after clicking? -->

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [ ] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
