### PR TITLE
Add election banner + wiki page

### DIFF
--- a/contents/markdown/elections.md
+++ b/contents/markdown/elections.md
@@ -1,0 +1,52 @@
+# Elections
+
+This page aims to provide an overview of important information related to the 2026 municipal election. For official information regarding the election, please visit [myvote.toronto.ca](https://myvote.toronto.ca).
+
+## Who can vote?
+
+To be eligible to vote you must be:
+- a Canadian citizen
+- at least 18 years old
+- a resident of Toronto OR an owner/renter of property in Toronto (or the spouse of one)
+
+For a complete list of requirements see [Who Can Vote](https://www.toronto.ca/city-government/elections/voter-information/who-can-vote/).
+
+You will be required to present one piece of **acceptable identification that has your name and address**. Photo ID is not required, and passports are not accepted as they don't contain your address. For more information see [Identification](https://www.toronto.ca/city-government/elections/voter-information/identification/).
+
+
+## Who can I vote for?
+
+Everyone votes for **Mayor** and **City Councillor**. You may also vote for one **School Board Trustee**, depending on which school board you're eligible for.
+
+- **Mayor** - elected city-wide. Every voter across Toronto votes for the same mayoral candidates.
+- **City Councillor** - elected by ward. Toronto has 25 wards, each with one councillor. You vote for the candidates running in your ward.
+- **School Board Trustee** - elected by school board ward. There are four school boards, each with its own ward boundaries (different from City wards). You vote for one trustee in one board:
+    - **Toronto District School Board** (English public) - 12 trustees, 12 wards
+    - **Toronto Catholic District School Board** (English Catholic) - 12 trustees, 12 wards
+    - **Conseil scolaire Viamonde** (French public) - 3 trustees, 3 wards
+    - **Conseil scolaire catholique MonAvenir** (French Catholic) - 2 trustees, 2 wards
+
+Which school board you vote for depends on your religion, language rights, and which board your school property taxes support. English public is the default unless you qualify for one of the other boards. See the [Who Can Vote](https://www.toronto.ca/city-government/elections/voter-information/who-can-vote/) page for the eligibility details.
+
+To see the candidates you are eligible to vote for, visit [MyVote](https://myvote.toronto.ca). For a full list of certified candidates, see [here](https://www.toronto.ca/city-government/elections/candidate-list/).
+
+## When/where can I vote?
+
+- **Election Day** - Monday, October 26, 2026, 10 a.m. to 8 p.m.
+- **Advance Voting** - Tuesday, October 6 to Sunday, October 11, 2026, 10 a.m. to 7 p.m.
+- **Vote by Mail** - Starting September 1, use the [MyVote](https://myvote.toronto.ca) tool to request a mail-in ballot.
+- **Find your voting location** - Use [MyVote](https://myvote.toronto.ca) starting September 1 to find where and when to vote, check your voter information, and see the candidates running in your ward.
+
+## How do I stay engaged after the election?
+
+There are several ways to influence decisions at City Hall year-round:
+
+- **Submit a deputation** - You can directly influence committee members by attending public meetings and sharing your views on an item before it reaches Council.
+- **Submit a comment** - You can also submit written comments on agenda items being considered by a committee.
+- **Call or email your Councillor** - They can advocate on your behalf and provide insight into ongoing decisions.
+- **Attend a consultation** - City staff hold consultations, surveys, and community meetings to gather feedback on new policies and projects.
+
+We also have more resources to help you engage:
+- [How City Council Works](https://civicdashboard.ca/how-council-works)
+- [Upcoming Items You Can Take Action On](https://civicdashboard.ca/actions)
+- [How Your Councillor Has Voted](https://civicdashboard.ca/councillors)

--- a/src/components/ElectionBanner.tsx
+++ b/src/components/ElectionBanner.tsx
@@ -11,15 +11,18 @@
  * tool switches from registration lookup to general election information.
  */
 const VOTER_INFO_PHASE_START = new Date('2026-10-12T00:00:00Z');
+const ELECTION_PAST_DATE = new Date('2026-10-27T00:00:00Z');
 const VOTER_INFO_URL = 'https://myvote.toronto.ca';
 
 export default function ElectionBanner() {
   const isVoterInfoPhase = new Date() >= VOTER_INFO_PHASE_START;
+  const isPastElection = new Date() >= ELECTION_PAST_DATE;
 
+  if (isPastElection) return null;
   return (
-    <div className="w-full bg-orange-700 text-white">
+    <div className="w-full bg-green-700 text-white">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
-        <p className="text-md font-semibold">
+        <p className="text-md text-center font-semibold">
           The Toronto municipal election is Monday, October 26, 2026.{' '}
           {isVoterInfoPhase ? (
             <>

--- a/src/components/ElectionBanner.tsx
+++ b/src/components/ElectionBanner.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+/**
+ * Site-wide election notification banner.
+ *
+ * Two states based on date:
+ * - Before Oct 12, 2026: voter registration check message
+ * - On/after Oct 12, 2026: general election info message
+ *
+ * The Oct 12 cutoff is when the City of Toronto's voter registration
+ * tool switches from registration lookup to general election information.
+ */
+const VOTER_INFO_PHASE_START = new Date('2026-10-12T00:00:00Z');
+const VOTER_INFO_URL = 'https://myvote.toronto.ca';
+
+export default function ElectionBanner() {
+  const isVoterInfoPhase = new Date() >= VOTER_INFO_PHASE_START;
+
+  return (
+    <div className="w-full bg-orange-700 text-white">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
+        <p className="text-md font-semibold">
+          The Toronto municipal election is Monday, October 26, 2026.{' '}
+          {isVoterInfoPhase ? (
+            <>
+              For more information visit{' '}
+              <a
+                href={VOTER_INFO_URL}
+                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                myvote.toronto.ca
+              </a>
+            </>
+          ) : (
+            <>
+              Make sure to check your voter registration at{' '}
+              <a
+                href={VOTER_INFO_URL}
+                className="underline"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                myvote.toronto.ca
+              </a>
+            </>
+          )}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/navigation/Header.tsx
+++ b/src/components/navigation/Header.tsx
@@ -4,7 +4,6 @@ import { menuItems } from '@/constants/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { ChevronDown, Menu, X } from 'lucide-react';
-import NotificationBanner from '@/components/navigation/NotificationBanner';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text-items';
 import {
@@ -13,6 +12,7 @@ import {
   AccordionTrigger,
   AccordionContent,
 } from '@/components/ui/accordion';
+import ElectionBanner from '@/components/ElectionBanner';
 
 // We need to declare the border classes for each color variant.
 // We apply these class names dynamically, so we need to declare them here to ensure they are included in the final CSS bundle.
@@ -54,10 +54,7 @@ export default function Header() {
 
   return (
     <>
-      <NotificationBanner
-        message="We love and need your feedback! Tap to share your thoughts."
-        link="/feedback"
-      />
+      <ElectionBanner />
       <header className="sticky top-0 z-30 bg-white dark:bg-black">
         <nav
           ref={desktopMenuRef}


### PR DESCRIPTION
## Description

Resolves #513

Adds a conditional banner to the site:

- Up to Oct 12th - `The Toronto municipal election is Monday, October 26, 2026. Make sure to check your voter registration at myvote.toronto.ca`
- Oct 12 - 26 - `The Toronto municipal election is Monday, October 26, 2026. For more information visit myvote.toronto.ca`
- Oct 27th onwards - disables banner


## Testing instructions

Banner:
- See preview URL
- Run locally, modify dates in the source code to see the different states

Wiki:
- See preview URL

## Checklist

<!-- Ensure you do these tasks before requesting a review! -->

- [x] This PR addresses all requirements described in the issue
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have performed a self-review of my code
- [x] I have tested these changes in my local environment
- [x] I have tested these changes in the preview site generated by this PR (you must finish opening the PR first)
- [x] I have made corresponding changes to the documentation (if relevant)
